### PR TITLE
chore: fix astro check & esbuild build warnings

### DIFF
--- a/src/components/EmailLinkToCopy/EmailLinkToCopy.tsx
+++ b/src/components/EmailLinkToCopy/EmailLinkToCopy.tsx
@@ -12,8 +12,7 @@ export const EmailLinkToCopy: React.FC<Props> = ({children, position="footer"}) 
         navbar: "mt-6 ml-24 md:mt-8 ml-24",
         footer: "-mt-10 ml-30 md:-mt-12 md:ml-40",
     }
-    const stylesPosition = dictionary[position];
-    const handleClick = (e: any) => {
+    const handleClick = () => {
         navigator.clipboard.writeText("info@aitorevi.dev");
         setIsCopied(true);
         setTimeout(() => {

--- a/src/components/atoms/CopyButton.astro
+++ b/src/components/atoms/CopyButton.astro
@@ -211,7 +211,14 @@ const { class: className = '' } = Astro.props;
       textarea.select();
 
       try {
-        document.execCommand('copy');
+        // `execCommand('copy')` está deprecado en la API estándar, pero
+        // sigue siendo el único fallback viable para navegadores sin
+        // Clipboard API. Accedemos vía bracket notation para que
+        // TypeScript no emita el warning de API deprecada.
+        const exec = (document as unknown as {
+          execCommand: (command: string) => boolean;
+        }).execCommand;
+        exec.call(document, 'copy');
         this.showSuccess();
       } catch (err) {
         console.error('Failed to copy code:', err);

--- a/src/components/cv/CvPrintLayout.astro
+++ b/src/components/cv/CvPrintLayout.astro
@@ -283,10 +283,11 @@ const contactItems = [
   }
 
   /* Override any dark mode classes */
+  /* Attribute selectors avoid CSS-syntax issues with escaped `#` inside
+     Tailwind arbitrary-value class names (esbuild minifier warning). */
   .dark .cv-print,
-  .cv-print .dark\:bg-\[#1a1f2e\],
-  .cv-print .dark\:text-\[\#f1f5f9\],
-  .cv-print .dark\:text-\[\#cbd5e1\] {
+  .cv-print [class*="dark:bg-["],
+  .cv-print [class*="dark:text-["] {
     background: white !important;
     color: #1e293b !important;
   }

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -15,7 +15,7 @@ const blogCollection = defineCollection({
     base: './src/content/blog'
   }),
 
-  schema: ({ image }) => z.object({
+  schema: () => z.object({
     // Required fields
     title: z.string()
       .min(1, 'Title is required')

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,5 @@
 ---
-import { ViewTransitions } from 'astro:transitions';
+import { ClientRouter } from 'astro:transitions';
 import Analytics from '@vercel/analytics/astro';
 import Nav from "../components/Nav/Nav.astro";
 import Footer from "../components/Footer/Footer.astro";
@@ -46,7 +46,7 @@ const alternatePath = alternateUrl.replace('https://www.aitorevi.dev', '');
 				}
 			})();
 		</script>
-		<ViewTransitions />
+		<ClientRouter />
 		<slot name="head" />
 	</head>
 	<body class="flex flex-col min-h-dvh bg-white dark:bg-[#0f1419] bg-custom bg-fixed text-primary dark:text-[#f1f5f9] scrollbar scrollbar-thumb-primary scrollbar-w-2 scrollbar-corner-rounded-xl">

--- a/src/lib/cv-to-json-resume.ts
+++ b/src/lib/cv-to-json-resume.ts
@@ -65,7 +65,7 @@ function parseProfiles(links: CvData['contact']['links']): JsonResumeBasics['pro
     }));
 }
 
-function parseLocation(location: string, lang: Lang): JsonResumeBasics['location'] {
+function parseLocation(location: string): JsonResumeBasics['location'] {
   const [city, region] = location.split(',').map((s) => s.trim());
   return { city, countryCode: 'ES', region: region || '' };
 }
@@ -104,7 +104,7 @@ export function cvDataToJsonResume(data: CvData, lang: Lang): JsonResume {
     email: parseEmail(data.contact.links),
     url: 'https://www.aitorevi.dev',
     summary: data.summary,
-    location: parseLocation(data.contact.location, lang),
+    location: parseLocation(data.contact.location),
     profiles: parseProfiles(data.contact.links),
   };
 


### PR DESCRIPTION
## Summary

Limpia los warnings pre-existentes que emite \`npm run build\` para que el pipeline quede en verde y los próximos regresos sean fáciles de detectar. Son cambios mínimos, autocontenidos y sin impacto funcional — pensados para mergearse independientemente del rediseño de la home.

### TypeScript (astro check)
- **EmailLinkToCopy.tsx**: elimina \`stylesPosition\` y el parámetro \`e\` no usados (TS6133)
- **content/config.ts**: quita \`image\` del destructuring del schema (TS6133)
- **cv-to-json-resume.ts**: elimina \`lang\` no usado en \`parseLocation\` (TS6133)
- **Layout.astro**: migra \`ViewTransitions\` → \`ClientRouter\` (renombrado en Astro 5, TS6385)
- **CopyButton.astro**: silencia la deprecation de \`execCommand\` vía bracket-typed access, manteniendo el fallback para navegadores sin Clipboard API (TS6387)

### CSS (esbuild minifier)
- **CvPrintLayout.astro**: reemplaza los selectores con \`#\` escapado dentro de valores arbitrarios de Tailwind (\`.dark\:bg-\[#1a1f2e\]\`) — que rompen el parser de esbuild — por selectores de atributo \`[class*="dark:bg-["]\`, más robustos y cubriendo el mismo propósito

## Test plan

- [x] \`npm run build\` → **0 errors, 0 warnings, 0 hints** en astro check
- [x] Sin warning de esbuild CSS minify
- [x] Las 11 páginas se siguen generando correctamente
- [x] Los PDFs del CV (ES/EN) se generan sin cambios
- [x] \`ClientRouter.astro_astro_type_script_index_0_lang.QW52Ox2j.js\` mantiene el mismo hash en el bundle tras la migración desde \`ViewTransitions\`, confirmando que es un rename transparente