### PR TITLE
feat(testimonials): randomize order on each page load

### DIFF
--- a/src/components/home/Testimonials.astro
+++ b/src/components/home/Testimonials.astro
@@ -1,5 +1,6 @@
 ---
 import { t } from '../../i18n/utils';
+import { shuffle } from '../../lib/array';
 import type { Lang } from '../../data/cv';
 
 interface Props {
@@ -41,6 +42,8 @@ const testimonials = lang === 'es'
         url: 'https://www.linkedin.com/in/francisco-correa-82a142234/',
       },
     ];
+
+const shuffled = shuffle(testimonials);
 ---
 
 <section
@@ -62,7 +65,7 @@ const testimonials = lang === 'es'
   <div class="carousel-wrapper mx-auto max-w-[640px] px-6">
     <!-- Cards stacked in the same grid cell -->
     <div class="carousel-track">
-      {testimonials.map((item, i) => {
+      {shuffled.map((item, i) => {
         const initials = item.author.split(' ').map((n: string) => n[0]).join('').slice(0, 2).toUpperCase();
         return (
           <div
@@ -128,7 +131,7 @@ const testimonials = lang === 'es'
 
     <!-- Dots -->
     <div class="mt-8 flex items-center justify-center gap-3" role="tablist" aria-label="Testimonials navigation">
-      {testimonials.map((item, i) => (
+      {shuffled.map((item, i) => (
         <button
           id={`testimonial-tab-${i}`}
           class:list={['dot', i === 0 ? 'active' : '']}

--- a/src/lib/array.ts
+++ b/src/lib/array.ts
@@ -1,0 +1,9 @@
+/** Fisher-Yates shuffle — returns a new shuffled copy, does not mutate the original. */
+export function shuffle<T>(arr: readonly T[]): T[] {
+  const copy = [...arr];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}

--- a/tests/unit/lib/array.test.ts
+++ b/tests/unit/lib/array.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shuffle } from '../../../src/lib/array';
+
+describe('shuffle', () => {
+  it('returns an array with the same elements', () => {
+    const input = [1, 2, 3, 4, 5];
+    const result = shuffle(input);
+    expect(result).toHaveLength(input.length);
+    expect(result.sort()).toEqual(input.sort());
+  });
+
+  it('does not mutate the original array', () => {
+    const input = [1, 2, 3, 4, 5];
+    const copy = [...input];
+    shuffle(input);
+    expect(input).toEqual(copy);
+  });
+
+  it('returns an empty array when given an empty array', () => {
+    expect(shuffle([])).toEqual([]);
+  });
+
+  it('returns a single-element array unchanged', () => {
+    expect(shuffle([42])).toEqual([42]);
+  });
+
+  it('produces a different order when Math.random is controlled', () => {
+    const input = ['a', 'b', 'c', 'd'];
+    // Force Math.random to always return 0 → swap with index 0 each time
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const result = shuffle(input);
+    expect(result).toEqual(['b', 'c', 'd', 'a']);
+    vi.restoreAllMocks();
+  });
+});


### PR DESCRIPTION
## Summary
- Extract Fisher-Yates shuffle to `src/lib/array.ts` (pure, immutable, tested)
- Shuffle testimonials server-side so the first one varies per visit
- Add 5 unit tests for the shuffle function

## Test plan
- [ ] `npx vitest run` — all tests pass
- [ ] Reload home page multiple times — first testimonial varies

🤖 Generated with [Claude Code](https://claude.com/claude-code)