### PR TITLE
perf(home): preload hero avatar image for better LCP

### DIFF
--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -4,5 +4,7 @@ import HomeContent from '../../components/HomeContent.astro';
 ---
 
 <Layout title="aitorevi.dev">
+    <link slot="head" rel="preload" as="image" href="/avatar-light.webp" fetchpriority="high" media="(prefers-color-scheme: light)" />
+    <link slot="head" rel="preload" as="image" href="/avatar.webp" fetchpriority="high" media="(prefers-color-scheme: dark)" />
     <HomeContent lang="en" />
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,5 +4,7 @@ import HomeContent from '../components/HomeContent.astro';
 ---
 
 <Layout title="aitorevi.dev">
+    <link slot="head" rel="preload" as="image" href="/avatar-light.webp" fetchpriority="high" media="(prefers-color-scheme: light)" />
+    <link slot="head" rel="preload" as="image" href="/avatar.webp" fetchpriority="high" media="(prefers-color-scheme: dark)" />
     <HomeContent lang="es" />
 </Layout>


### PR DESCRIPTION
## Summary
Closes #10. Preload the avatar image on the home page (ES + EN) so the browser starts downloading it in parallel with HTML/CSS parsing, improving the LCP metric.

Uses `media="(prefers-color-scheme: light|dark)"` so only the relevant variant gets preloaded based on the user's system preference.

## Test plan
- [ ] Home page (ES + EN) still renders correctly
- [ ] DevTools Network: `avatar-*.webp` loads earlier than before
- [ ] Lighthouse LCP score improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)