### PR TITLE
seo(home): add JSON-LD Person schema

### DIFF
--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1,10 +1,29 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import HomeContent from '../../components/HomeContent.astro';
+
+const personSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: 'Aitor Reviriego Amor',
+    url: 'https://www.aitorevi.dev/en',
+    image: 'https://www.aitorevi.dev/avatar.webp',
+    jobTitle: 'Full Stack Developer',
+    worksFor: {
+        '@type': 'Organization',
+        name: 'Lean Mind',
+        url: 'https://leanmind.es',
+    },
+    sameAs: [
+        'https://es.linkedin.com/in/aitor-reviriego-amor',
+        'https://github.com/aitorevi',
+    ],
+};
 ---
 
 <Layout title="aitorevi.dev">
     <link slot="head" rel="preload" as="image" href="/avatar-light.webp" fetchpriority="high" media="(prefers-color-scheme: light)" />
     <link slot="head" rel="preload" as="image" href="/avatar.webp" fetchpriority="high" media="(prefers-color-scheme: dark)" />
+    <script slot="head" is:inline type="application/ld+json" set:html={JSON.stringify(personSchema)}></script>
     <HomeContent lang="en" />
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,29 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import HomeContent from '../components/HomeContent.astro';
+
+const personSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: 'Aitor Reviriego Amor',
+    url: 'https://www.aitorevi.dev',
+    image: 'https://www.aitorevi.dev/avatar.webp',
+    jobTitle: 'Full Stack Developer',
+    worksFor: {
+        '@type': 'Organization',
+        name: 'Lean Mind',
+        url: 'https://leanmind.es',
+    },
+    sameAs: [
+        'https://es.linkedin.com/in/aitor-reviriego-amor',
+        'https://github.com/aitorevi',
+    ],
+};
 ---
 
 <Layout title="aitorevi.dev">
     <link slot="head" rel="preload" as="image" href="/avatar-light.webp" fetchpriority="high" media="(prefers-color-scheme: light)" />
     <link slot="head" rel="preload" as="image" href="/avatar.webp" fetchpriority="high" media="(prefers-color-scheme: dark)" />
+    <script slot="head" is:inline type="application/ld+json" set:html={JSON.stringify(personSchema)}></script>
     <HomeContent lang="es" />
 </Layout>


### PR DESCRIPTION
## Summary
Closes #4. Add schema.org Person JSON-LD to both home pages so Google understands the site represents a real person, and can link it with LinkedIn + GitHub profiles via \`sameAs\`.

## Test plan
- [ ] Validate with https://validator.schema.org after deploy
- [ ] View source on home: JSON-LD script present in <head>

🤖 Generated with [Claude Code](https://claude.com/claude-code)