### PR TITLE
fix(a11y): keyboard nav + focus tooltip on code blocks

### DIFF
--- a/src/components/atoms/CopyButton.astro
+++ b/src/components/atoms/CopyButton.astro
@@ -74,7 +74,7 @@ const { class: className = '', copyLabel = 'Copy', copiedLabel = 'Copied!' } = A
 
   <!-- Tooltip -->
   <span
-    class="tooltip pointer-events-none absolute -top-9 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-slate-800 px-2 py-1 text-xs font-medium text-white opacity-0 shadow-md transition-opacity duration-150 group-hover:opacity-100"
+    class="tooltip pointer-events-none absolute -top-9 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-slate-800 px-2 py-1 text-xs font-medium text-white opacity-0 shadow-md transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100"
     aria-hidden="true"
   >
     {copyLabel}

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -104,6 +104,7 @@ export const ui: Record<Lang, Record<string, string>> = {
     'portfolio.ims.gallery.mobileDesc': 'PWA instalable. Acceso rápido desde el móvil sin necesidad de App Store.',
     'blog.copyCode': 'Copiar',
     'blog.copied': '¡Copiado!',
+    'blog.codeBlock': 'Bloque de código',
     'home.p1':
       'Soy un superhéroe detrás del teclado, embarcándome en una épica aventura para desentrañar los misterios del Código de Calidad. No es cualquier código... es código para humanos.',
     'home.p2':
@@ -233,6 +234,7 @@ export const ui: Record<Lang, Record<string, string>> = {
     'portfolio.ims.gallery.mobileDesc': 'Installable PWA. Fast access from mobile without the App Store.',
     'blog.copyCode': 'Copy',
     'blog.copied': 'Copied!',
+    'blog.codeBlock': 'Code block',
     'home.p1':
       "I'm a keyboard superhero, embarking on an epic adventure to unravel the mysteries of Quality Code. Not just any code... code for humans. My mission is clear: writing elegant code.",
     'home.p2':

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -246,6 +246,7 @@ const coverImageAbsolute = toAbsoluteUrl(coverImageUrl);
       class="prose prose-slate dark:prose-invert max-w-none prose-headings:font-semibold prose-headings:tracking-tight prose-a:text-blue-600 dark:prose-a:text-blue-400 hover:prose-a:text-blue-700 dark:hover:prose-a:text-blue-300 prose-img:rounded-lg prose-img:max-h-[600px] prose-img:w-auto prose-img:mx-auto prose-img:object-contain"
       itemprop="articleBody"
       id="article-content"
+      data-code-block-label={t(lang, 'blog.codeBlock')}
     >
       <Content />
     </div>
@@ -669,7 +670,14 @@ const coverImageAbsolute = toAbsoluteUrl(coverImageUrl);
     });
   }
 
-  function wrapStandaloneCodeBlocks(content: HTMLElement) {
+  function makeCodeBlockAccessible(pre: Element, label: string) {
+    // WCAG 2.1 SC 2.1.1 — scrollable regions must be keyboard-operable.
+    if (!pre.hasAttribute('tabindex')) pre.setAttribute('tabindex', '0');
+    if (!pre.hasAttribute('role')) pre.setAttribute('role', 'region');
+    if (!pre.hasAttribute('aria-label')) pre.setAttribute('aria-label', label);
+  }
+
+  function wrapStandaloneCodeBlocks(content: HTMLElement, label: string) {
     const template = document.getElementById('copy-button-template') as HTMLTemplateElement;
     if (!template) return;
 
@@ -682,6 +690,7 @@ const coverImageAbsolute = toAbsoluteUrl(coverImageUrl);
       pre.parentNode?.replaceChild(wrapper, pre);
       wrapper.appendChild(pre);
       wrapper.appendChild(button);
+      makeCodeBlockAccessible(pre, label);
     });
   }
 
@@ -689,8 +698,11 @@ const coverImageAbsolute = toAbsoluteUrl(coverImageUrl);
     const content = document.getElementById('article-content');
     if (!content) return;
 
+    const label = content.dataset.codeBlockLabel || 'Code block';
+
     processCodeGroups(content);
-    wrapStandaloneCodeBlocks(content);
+    wrapStandaloneCodeBlocks(content, label);
+    content.querySelectorAll('.code-group pre').forEach((pre) => makeCodeBlockAccessible(pre, label));
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- `<pre>` elements now get `tabindex=0`, `role=region` and a localized `aria-label` so keyboard users can focus and horizontally scroll them (WCAG 2.1 SC 2.1.1)
- Copy button tooltip now shows on `:focus-visible`, not only `:hover`, so keyboard users see the "Copy" label when tabbing onto the button
- Closes #8

## Test plan
- [x] `npm run build` passes
- [ ] Tab to a code block on an ES post — focus ring appears on `<pre>`, arrow keys scroll horizontally
- [ ] Tab to copy button — tooltip "Copiar" visible without hover
- [ ] Enter/Space on copy button copies code

## Notes
The EN blog page (`src/pages/en/blog/[...slug].astro`) is missing the code-block wrapping script entirely, so EN posts render raw `<pre>` without copy buttons. That's a separate pre-existing bug; out of scope for #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)