### PR TITLE
refactor: extract dark radial gradient to Layout variant prop

### DIFF
--- a/src/components/blog/BlogPage.astro
+++ b/src/components/blog/BlogPage.astro
@@ -26,6 +26,7 @@ const regularPosts = publishedPosts.filter((post) => !post.data.featured);
 <Layout
   title="Blog | aitorevi"
   description={t(lang, 'blog.description')}
+  variant="dark-radial"
 >
   <Fragment slot="head">
     <meta property="og:type" content="website" />
@@ -108,19 +109,6 @@ const regularPosts = publishedPosts.filter((post) => !post.data.featured);
     )}
   </div>
   </div>
-  <style is:global>
-    body:has(.blog-page) {
-      background-color: #f8fafc;
-      background-image: none;
-    }
-    html.dark body:has(.blog-page),
-    html.dark body:has(.blog-page) main {
-      background-color: #020617;
-      background-image: radial-gradient(ellipse at 30% 20%, #0f172a 0%, #020617 55%, #000 100%);
-      background-attachment: fixed;
-      background-size: cover;
-    }
-  </style>
 </Layout>
 
 <style>

--- a/src/components/cv/CvPage.astro
+++ b/src/components/cv/CvPage.astro
@@ -26,6 +26,7 @@ const jsonPath = getJsonPath(lang);
   title={data.labels.pageTitle}
   lang={lang}
   description={data.labels.pageDescription}
+  variant="dark-radial"
 >
   <div class="relative isolate min-h-[calc(100vh-3.5rem)] md:min-h-[calc(100vh-5rem)]">
     <!-- Dark-mode-only dot field — same logic as home hero -->
@@ -42,17 +43,4 @@ const jsonPath = getJsonPath(lang);
       <CvPdfDownload pdfPath={pdfPath} jsonPath={jsonPath} label={data.labels.downloadPdf} />
     </section>
   </div>
-  <style is:global>
-    body:has(.cv-page) {
-      background-color: #f8fafc;
-      background-image: none;
-    }
-    html.dark body:has(.cv-page),
-    html.dark body:has(.cv-page) main {
-      background-color: #020617;
-      background-image: radial-gradient(ellipse at 30% 20%, #0f172a 0%, #020617 55%, #000 100%);
-      background-attachment: fixed;
-      background-size: cover;
-    }
-  </style>
 </Layout>

--- a/src/components/katas/KatasPage.astro
+++ b/src/components/katas/KatasPage.astro
@@ -173,17 +173,6 @@ const techs = [...techFrequency.entries()]
 </script>
 
 <style is:global>
-  body:has(.katas-page) {
-    background-color: #f8fafc;
-    background-image: none;
-  }
-  html.dark body:has(.katas-page),
-  html.dark body:has(.katas-page) main {
-    background-color: #020617;
-    background-image: radial-gradient(ellipse at 30% 20%, #0f172a 0%, #020617 55%, #000 100%);
-    background-attachment: fixed;
-    background-size: cover;
-  }
   [data-kata-card][hidden] {
     display: none !important;
   }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -13,6 +13,8 @@ interface Props {
 	alternateUrl?: string;
 	alternateLang?: Lang;
 	ogImage?: string;
+	/** Background variant. `dark-radial` applies the slate palette + radial gradient used on content pages (cv, blog, katas). */
+	variant?: 'default' | 'dark-radial';
 }
 
 const currentLang = getLangFromUrl(Astro.url);
@@ -23,6 +25,7 @@ const {
 	alternateUrl = `https://www.aitorevi.dev${getAlternateUrl(Astro.url.pathname, lang)}`,
 	alternateLang = lang === 'es' ? 'en' : 'es',
 	ogImage = '/og-image.png',
+	variant = 'default',
 } = Astro.props;
 
 const alternatePath = alternateUrl.replace('https://www.aitorevi.dev', '');
@@ -75,7 +78,10 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `https://www.aitorevi.
 		<ClientRouter />
 		<slot name="head" />
 	</head>
-	<body class="flex flex-col min-h-dvh bg-white dark:bg-[#0f1419] text-primary dark:text-[#f1f5f9] scrollbar scrollbar-thumb-primary scrollbar-w-2 scrollbar-corner-rounded-xl">
+	<body
+		class="flex flex-col min-h-dvh bg-white dark:bg-[#0f1419] text-primary dark:text-[#f1f5f9] scrollbar scrollbar-thumb-primary scrollbar-w-2 scrollbar-corner-rounded-xl"
+		data-bg={variant === 'default' ? undefined : variant}
+	>
 		<a
 			href="#main-content"
 			class="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:top-4 focus:left-4 focus:rounded focus:bg-white dark:focus:bg-ink-900 focus:px-4 focus:py-2 focus:text-secondary focus:shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary"
@@ -91,6 +97,18 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `https://www.aitorevi.
 	</body>
 </html>
 <style is:global>
+	body[data-bg="dark-radial"] {
+		background-color: #f8fafc;
+		background-image: none;
+	}
+	html.dark body[data-bg="dark-radial"],
+	html.dark body[data-bg="dark-radial"] main {
+		background-color: #020617;
+		background-image: radial-gradient(ellipse at 30% 20%, #0f172a 0%, #020617 55%, #000 100%);
+		background-attachment: fixed;
+		background-size: cover;
+	}
+
 	::-webkit-scrollbar {
 		height: .6rem;
 		width: .5rem;

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -97,6 +97,7 @@ const coverImageAbsolute = toAbsoluteUrl(coverImageUrl);
   title={`${data.title} | aitorevi Blog`}
   description={data.description}
   alternateUrl={`https://www.aitorevi.dev${alternateUrl}`}
+  variant="dark-radial"
 >
   <!-- SEO: Open Graph & Twitter Card -->
   <Fragment slot="head">
@@ -314,19 +315,6 @@ const coverImageAbsolute = toAbsoluteUrl(coverImageUrl);
     <meta itemprop="author" content={data.author.name} />
   </article>
   </div>
-  <style is:global>
-    body:has(.blog-page) {
-      background-color: #f8fafc;
-      background-image: none;
-    }
-    html.dark body:has(.blog-page),
-    html.dark body:has(.blog-page) main {
-      background-color: #020617;
-      background-image: radial-gradient(ellipse at 30% 20%, #0f172a 0%, #020617 55%, #000 100%);
-      background-attachment: fixed;
-      background-size: cover;
-    }
-  </style>
 </Layout>
 
 <style is:global>

--- a/src/pages/en/blog/[...slug].astro
+++ b/src/pages/en/blog/[...slug].astro
@@ -59,6 +59,7 @@ const coverImageAbsolute = toAbsoluteUrl(coverImageUrl);
   title={`${data.title} | aitorevi Blog`}
   description={data.description}
   alternateUrl={`https://www.aitorevi.dev${alternateUrl}`}
+  variant="dark-radial"
 >
   <Fragment slot="head">
     <meta property="og:type" content="article" />
@@ -239,19 +240,6 @@ const coverImageAbsolute = toAbsoluteUrl(coverImageUrl);
     <meta itemprop="author" content={data.author.name} />
   </article>
   </div>
-  <style is:global>
-    body:has(.blog-page) {
-      background-color: #f8fafc;
-      background-image: none;
-    }
-    html.dark body:has(.blog-page),
-    html.dark body:has(.blog-page) main {
-      background-color: #020617;
-      background-image: radial-gradient(ellipse at 30% 20%, #0f172a 0%, #020617 55%, #000 100%);
-      background-attachment: fixed;
-      background-size: cover;
-    }
-  </style>
 </Layout>
 
 <style is:global>

--- a/src/pages/en/katas/index.astro
+++ b/src/pages/en/katas/index.astro
@@ -11,7 +11,7 @@ const canonicalUrl = `https://www.aitorevi.dev${Astro.url.pathname}`;
 const schema = buildKatasCollectionSchema(lang, canonicalUrl, metaTitle, metaDescription);
 ---
 
-<Layout title={metaTitle} description={metaDescription} lang={lang} ogImage="/og-katas.png">
+<Layout title={metaTitle} description={metaDescription} lang={lang} ogImage="/og-katas.png" variant="dark-radial">
   <script slot="head" is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
   <KatasPage lang={lang} />
 </Layout>

--- a/src/pages/katas/index.astro
+++ b/src/pages/katas/index.astro
@@ -11,7 +11,7 @@ const canonicalUrl = `https://www.aitorevi.dev${Astro.url.pathname}`;
 const schema = buildKatasCollectionSchema(lang, canonicalUrl, metaTitle, metaDescription);
 ---
 
-<Layout title={metaTitle} description={metaDescription} lang={lang} ogImage="/og-katas.png">
+<Layout title={metaTitle} description={metaDescription} lang={lang} ogImage="/og-katas.png" variant="dark-radial">
   <script slot="head" is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
   <KatasPage lang={lang} />
 </Layout>


### PR DESCRIPTION
## Summary

- The `<style is:global>` block with `body:has(.X-page)` + radial gradient was duplicated across 5 files (CvPage, BlogPage, KatasPage, `blog/[...slug].astro` ES + EN). Tuning the gradient required touching every page.
- Moves the CSS to a single `data-bg="dark-radial"` rule on `<body>` inside `Layout.astro`. Pages opt in via `<Layout variant="dark-radial">`.
- The `.cv-page` / `.blog-page` / `.katas-page` scope classes stay in place as anchors for other page-specific styles (scroll reveals, empty states, etc).
- Home page (flat `#f8fafc` / `#020617` without gradient) is untouched — lives in a single file already, not duplicated.

## Test plan

- [x] `npx astro check` — 0 errors
- [x] `npm test -- --run` — 127/127 passing
- [x] `npm run build` — green, OG images and CV PDFs regenerate
- [ ] Vercel preview: compare `/cv`, `/blog`, any blog post, `/katas` light + dark against master visually — should be pixel-identical
- [ ] Check ES + EN routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)