### PR TITLE
feat(blog): add 'strict mocks vs fakes' article + link Mock 101 talk to it

### DIFF
--- a/src/components/home/Talks.astro
+++ b/src/components/home/Talks.astro
@@ -35,7 +35,9 @@ const sorted = [...talks].sort((a, b) => (a.date < b.date ? 1 : -1));
       class="mt-14 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3"
       data-stagger-root
     >
-      {sorted.map((talk, i) => (
+      {sorted.map((talk, i) => {
+        const articleUrl = talk.articleUrl?.[lang];
+        return (
         <li
           class="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white p-6 shadow-lg backdrop-blur-md transition-[border-color,box-shadow,background-color] duration-500 hover:border-secondary/40 hover:shadow-[0_20px_50px_-20px_rgba(94,58,238,0.35)] dark:border-white/10 dark:bg-white/[0.04] dark:shadow-2xl dark:hover:border-accent-blue/40 dark:hover:bg-white/[0.07] dark:hover:shadow-[0_0_60px_rgba(96,165,250,0.15)]"
           data-stagger-item
@@ -53,11 +55,9 @@ const sorted = [...talks].sort((a, b) => (a.date < b.date ? 1 : -1));
             </span>
 
             <h3 class="font-display text-lg font-semibold text-ink-900 dark:text-slate-100">
-              {talk.articleUrl ? (
+              {articleUrl ? (
                 <a
-                  href={talk.articleUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  href={articleUrl}
                   class="after:absolute after:inset-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2"
                 >
                   {talk.title}
@@ -106,7 +106,8 @@ const sorted = [...talks].sort((a, b) => (a.date < b.date ? 1 : -1));
             )}
           </div>
         </li>
-      ))}
+        );
+      })}
     </ul>
   </div>
 </section>

--- a/src/content/blog/en/strict-mocks-vs-fakes.md
+++ b/src/content/blog/en/strict-mocks-vs-fakes.md
@@ -1,0 +1,147 @@
+---
+title: 'Strict mocks vs fakes: when green is a lie'
+description: >-
+  A test can be green and still hide a bug. The difference between a strict
+  mock and a fake is not theoretical — it changes what you are verifying.
+publishDate: 2026-04-21
+tags:
+  - Testing
+  - TDD
+  - Mocks
+  - Test Doubles
+draft: false
+author:
+  name: aitorevi
+  avatar: /avatar.webp
+---
+A green test should mean "this works". But there is a kind of test that stays green even when the code is broken, and another that goes red even when the code is fine. They are the same test — only the double underneath has changed.
+
+The first case is a strict mock misused. The second, also. The difference with a fake is not syntax: it is what you are verifying when you look at the green bar.
+
+## The test that lies
+
+Picture a simple use case: register a user and send them a welcome email.
+
+```java
+class RegisterUser {
+    private final UserRepository users;
+    private final EmailGateway emails;
+
+    public RegisterUser(UserRepository users, EmailGateway emails) {
+        this.users = users;
+        this.emails = emails;
+    }
+
+    public void execute(String address) {
+        var user = new User(address);
+        users.save(user);
+        emails.send(address, "Welcome!", "Thanks for signing up.");
+    }
+}
+```
+
+With a strict mock, the typical test looks like this:
+
+```java
+@Test
+void registers_user_and_sends_welcome_email() {
+    var users = mock(UserRepository.class);
+    var emails = mock(EmailGateway.class);
+    var register = new RegisterUser(users, emails);
+
+    register.execute("alice@example.com");
+
+    verify(users).save(any(User.class));
+    verify(emails).send(eq("alice@example.com"), eq("Welcome!"), anyString());
+}
+```
+
+It is green. And at first glance it seems fine: it verifies that the user is saved and the email is sent. But look at what you are actually asserting: that `save` **was called** with some `User`, and that `send` **was called** with a subject exactly equal to `"Welcome!"`.
+
+You are not verifying that the user ends up stored. You are not verifying that the email carries useful information. You are verifying **the shape of the calls**, not the effect they produce.
+
+## The trap: coupling to the "how"
+
+The day someone decides `EmailGateway.send` should take a single `Email` object instead of three strings — so they can add attachments without breaking twenty callers — your test goes red. Not because the behaviour broke. It goes red because the call signature changed.
+
+You are left choosing between two equally bad paths:
+
+1. **Rewrite the test** so it matches the new signature. Repeat for every internal refactor, and what was a safety net becomes dead weight.
+2. **Abandon the refactor** to avoid touching tests. Congratulations: the strict mock just became a brake on design.
+
+The same test can fail worse in the opposite direction. If one day someone replaces `emails.send(...)` with an internal queue and keeps the facade happy, the mock stays green. You verified a call that no longer reflects the system's actual behaviour.
+
+Green when it should be red. Red when it should be green. Two sides of the same coin: you are testing interactions, not behaviour.
+
+## The fake: verifying what matters
+
+A fake is a simple, in-memory implementation of the same interface that actually works. It does not record calls: it stores data, returns it, compares it. It is a real dependency in miniature.
+
+```java
+class InMemoryEmailGateway implements EmailGateway {
+    private final List<Email> sent = new ArrayList<>();
+
+    @Override
+    public void send(String to, String subject, String body) {
+        sent.add(new Email(to, subject, body));
+    }
+
+    public boolean welcomeWasSentTo(String address) {
+        return sent.stream()
+            .anyMatch(e -> e.to().equals(address) && e.subject().contains("Welcome"));
+    }
+}
+
+class InMemoryUserRepository implements UserRepository {
+    private final Map<String, User> users = new HashMap<>();
+
+    @Override public void save(User user) { users.put(user.email(), user); }
+    public Optional<User> findByEmail(String email) { return Optional.ofNullable(users.get(email)); }
+}
+```
+
+The test shifts radically in what it asserts:
+
+```java
+@Test
+void registers_user_and_sends_welcome_email() {
+    var users = new InMemoryUserRepository();
+    var emails = new InMemoryEmailGateway();
+    var register = new RegisterUser(users, emails);
+
+    register.execute("alice@example.com");
+
+    assertThat(users.findByEmail("alice@example.com")).isPresent();
+    assertThat(emails.welcomeWasSentTo("alice@example.com")).isTrue();
+}
+```
+
+No more `verify`. Just `assertThat`. You are asserting the **state** of the system after the use case: the user exists, the welcome email went out. If tomorrow `send` starts taking an `Email` instead of three strings, your test stays green as long as the behaviour holds. If someone silently breaks the email dispatch, the test goes red because `welcomeWasSentTo` returns `false`.
+
+You are verifying the what, not the how.
+
+## So are strict mocks useless?
+
+No. There is a legitimate place for them: when the interaction **is** the observable behaviour. If you are testing an adapter whose only job is to call an external API with a specific payload, what you want to verify is exactly that — that the call happened, with those arguments. There, the strict mock is the right tool.
+
+The rule I use in practice:
+
+- **Outbound port with its own semantics** (repository, email, cache) → fake. What matters is the resulting state.
+- **Outbound port that is pure pass-through** (HTTP adapter, SDK client) → mock. What matters is the call.
+- **Domain logic** → no doubles. Real objects.
+
+The smoke signal that you are picking the wrong tool is easy to spot: if your test has `verify` on something that owns state — a repository, a cache, a queue — you probably want a fake.
+
+## The cost of a fake
+
+It has an obvious one: you write it. An `InMemoryUserRepository` does not materialise out of thin air like a `mock(...)`. And if you change the interface, you have to change the fake.
+
+But that is precisely what makes it valuable. The fake **also** has to follow the port's design. If the interface forces you to do weird things in the fake, the interface is probably wrong. Fakes are design feedback; mocks are not.
+
+And if you have eight tests sharing the same fake, you wrote the fake once. With eight strict mocks, you configured it eight times.
+
+## If you want to see it in more languages
+
+We took this idea to a workshop with [Aitor Santana](https://www.linkedin.com/in/aitorsantanacabrera/) at Nerdearla: **Mock 101**. We covered dummies, stubs, spies, strict mocks, and fakes, with parallel examples in Java, Kotlin, TypeScript, Python, C#, and Go. All the code lives at [github.com/Sstark97/mock-101](https://github.com/Sstark97/mock-101), and the official recap is on the [Lean Mind blog](https://leanmind.es/es/blog/mock-101-el-arte-del-testing-una-experiencia-unica-en-nerdearla).
+
+If you take one thing from all this: before writing `verify(...)` in your next test, ask yourself whether what you care about is the call or the effect. If it is the effect, write a fake. Green will go back to meaning things actually work.

--- a/src/content/blog/es/strict-mocks-vs-fakes.md
+++ b/src/content/blog/es/strict-mocks-vs-fakes.md
@@ -1,0 +1,147 @@
+---
+title: 'Strict mocks vs fakes: cuando el verde es mentira'
+description: >-
+  Un test puede estar en verde y aun así ocultar un bug. La diferencia entre
+  strict mock y fake no es teórica: cambia qué estás verificando.
+publishDate: 2026-04-21
+tags:
+  - Testing
+  - TDD
+  - Mocks
+  - Test Doubles
+draft: false
+author:
+  name: aitorevi
+  avatar: /avatar.webp
+---
+Un test en verde debería significar "esto funciona". Pero hay un tipo de test que se queda verde aunque el código esté roto, y hay otro que se pone en rojo aunque el código esté bien. Son el mismo test, solo que con un doble distinto debajo.
+
+El primer caso es un strict mock mal usado. El segundo, también. La diferencia con un fake no es de sintaxis: es de qué estás verificando exactamente cuando miras el verde.
+
+## El test que miente
+
+Imagina un caso de uso sencillo: registrar un usuario y enviarle un email de bienvenida.
+
+```java
+class RegisterUser {
+    private final UserRepository users;
+    private final EmailGateway emails;
+
+    public RegisterUser(UserRepository users, EmailGateway emails) {
+        this.users = users;
+        this.emails = emails;
+    }
+
+    public void execute(String address) {
+        var user = new User(address);
+        users.save(user);
+        emails.send(address, "Welcome!", "Thanks for signing up.");
+    }
+}
+```
+
+Con un strict mock, el test típico queda así:
+
+```java
+@Test
+void registers_user_and_sends_welcome_email() {
+    var users = mock(UserRepository.class);
+    var emails = mock(EmailGateway.class);
+    var register = new RegisterUser(users, emails);
+
+    register.execute("alice@example.com");
+
+    verify(users).save(any(User.class));
+    verify(emails).send(eq("alice@example.com"), eq("Welcome!"), anyString());
+}
+```
+
+Está en verde. Y a primera vista parece bueno: verifica que se guarda al usuario y que se envía el email. Pero fíjate en lo que realmente estás asertando: que se **llamó a `save`** con un `User` cualquiera, y que se **llamó a `send`** con un asunto exactamente igual a `"Welcome!"`.
+
+No estás verificando que el usuario quede guardado. No estás verificando que el email contenga información útil. Estás verificando **la firma de las llamadas**, no el efecto que producen.
+
+## La trampa: acoplarte al "cómo"
+
+El día que alguien decide que `EmailGateway.send` debería recibir un objeto `Email` en vez de tres strings —porque así se pueden añadir adjuntos sin romper a veinte callers—, tu test se pone en rojo. No porque el comportamiento esté mal. Se pone en rojo porque la forma de la llamada cambió.
+
+Acabas eligiendo entre dos caminos igual de malos:
+
+1. **Reescribir el test** para que case con la nueva firma. Repítelo por cada refactor interno y lo que tenías era una red de seguridad; ahora es un lastre.
+2. **Dejar el refactor a medias** para no tocar tests. Enhorabuena: el strict mock acaba de convertirse en un freno al diseño.
+
+El mismo test puede fallar peor en el sentido contrario. Si un día alguien sustituye `emails.send(...)` por una cola interna y no toca la fachada, el mock se queda en verde. Has verificado una llamada que ya no representa el comportamiento real del sistema.
+
+Verde cuando debería estar rojo. Rojo cuando debería estar verde. Las dos caras de la misma moneda: estás testando interacciones, no comportamiento.
+
+## El fake: verificar lo que importa
+
+Un fake es una implementación simple de la misma interfaz, que funciona de verdad en memoria. No graba llamadas: guarda datos, los devuelve, los compara. Es una dependencia real en miniatura.
+
+```java
+class InMemoryEmailGateway implements EmailGateway {
+    private final List<Email> sent = new ArrayList<>();
+
+    @Override
+    public void send(String to, String subject, String body) {
+        sent.add(new Email(to, subject, body));
+    }
+
+    public boolean welcomeWasSentTo(String address) {
+        return sent.stream()
+            .anyMatch(e -> e.to().equals(address) && e.subject().contains("Welcome"));
+    }
+}
+
+class InMemoryUserRepository implements UserRepository {
+    private final Map<String, User> users = new HashMap<>();
+
+    @Override public void save(User user) { users.put(user.email(), user); }
+    public Optional<User> findByEmail(String email) { return Optional.ofNullable(users.get(email)); }
+}
+```
+
+El test cambia radicalmente de lo que afirma:
+
+```java
+@Test
+void registers_user_and_sends_welcome_email() {
+    var users = new InMemoryUserRepository();
+    var emails = new InMemoryEmailGateway();
+    var register = new RegisterUser(users, emails);
+
+    register.execute("alice@example.com");
+
+    assertThat(users.findByEmail("alice@example.com")).isPresent();
+    assertThat(emails.welcomeWasSentTo("alice@example.com")).isTrue();
+}
+```
+
+Ya no hay `verify`. Hay `assertThat`. Afirmas el **estado** del sistema después del caso de uso: que existe el usuario, que se envió el email de bienvenida. Si mañana `send` pasa a recibir un `Email` en vez de tres strings, tu test sigue en verde si el comportamiento se mantiene. Si alguien se cargara el envío de emails silenciosamente, el test se pone en rojo porque `welcomeWasSentTo` devuelve `false`.
+
+Estás verificando el qué, no el cómo.
+
+## Entonces, ¿los strict mocks sobran?
+
+No. Hay un sitio legítimo para ellos: cuando la interacción **es** el comportamiento observable. Si estás testando un adapter cuyo único trabajo es llamar a una API externa con un payload específico, lo que quieres verificar es exactamente eso: que se hizo la llamada, con esos argumentos. Ahí el strict mock es la herramienta correcta.
+
+La regla que uso en la práctica:
+
+- **Puerto de salida con semántica propia** (repositorio, email, cache) → fake. Lo que importa es el estado que queda.
+- **Puerto de salida que es puro pass-through** (adapter HTTP, cliente SDK) → mock. Lo que importa es la llamada.
+- **Lógica de dominio** → sin dobles. Objetos reales.
+
+El síntoma de que te estás equivocando es fácil de detectar: si tu test tiene `verify` sobre algo que tiene estado propio —un repositorio, un cache, una cola—, probablemente quieres un fake.
+
+## El coste del fake
+
+Tiene uno obvio: lo escribes tú. Un `InMemoryUserRepository` no aparece por arte de magia como un `mock(...)`. Y si cambias la interfaz, tienes que cambiar el fake.
+
+Pero eso es exactamente lo que lo hace valioso. El fake **también** tiene que seguir el diseño del puerto. Si la interfaz te exige hacer cosas raras en el fake, probablemente la interfaz esté mal. Los fakes son feedback de diseño; los mocks, no.
+
+Y si tienes ocho tests que usan el mismo fake, el fake lo escribiste una vez. Si son ocho strict mocks, lo has configurado ocho veces.
+
+## Si quieres verlo en más lenguajes
+
+Esta idea la llevamos a un taller con [Aitor Santana](https://www.linkedin.com/in/aitorsantanacabrera/) en Nerdearla: **Mock 101**. Allí tocamos dummies, stubs, spies, mocks estrictos y fakes, con ejemplos paralelos en Java, Kotlin, TypeScript, Python, C# y Go. El código está todo en [github.com/Sstark97/mock-101](https://github.com/Sstark97/mock-101), y la crónica oficial en el [blog de Lean Mind](https://leanmind.es/es/blog/mock-101-el-arte-del-testing-una-experiencia-unica-en-nerdearla).
+
+Si te llevas una sola cosa de aquí: antes de escribir `verify(...)` en tu próximo test, pregúntate si lo que te importa es la llamada o el efecto. Si es el efecto, escribe un fake. El verde volverá a significar que las cosas funcionan.

--- a/src/data/talks.ts
+++ b/src/data/talks.ts
@@ -8,7 +8,7 @@ export interface Talk {
   coPresenters?: string[];
   description: Record<Lang, string>;
   tags: string[];
-  articleUrl?: string;
+  articleUrl?: Record<Lang, string>;
   githubUrl?: string;
 }
 
@@ -23,7 +23,10 @@ export const talks: Talk[] = [
       en: 'Workshop covering the fundamentals of test doubles: dummies, stubs, spies, strict mocks, and fakes. Examples in Java, Python, TypeScript, C#, Go, and Kotlin to grasp when and why to use each.',
     },
     tags: ['Testing', 'Mocks', 'TDD'],
-    articleUrl: 'https://leanmind.es/es/blog/mock-101-el-arte-del-testing-una-experiencia-unica-en-nerdearla',
+    articleUrl: {
+      es: '/blog/strict-mocks-vs-fakes',
+      en: '/en/blog/strict-mocks-vs-fakes',
+    },
     githubUrl: 'https://github.com/Sstark97/mock-101',
   },
 ];


### PR DESCRIPTION
## Summary
- New blog post (ES + EN): **Strict mocks vs fakes: cuando el verde es mentira** / **when green is a lie**
- Opinion-driven: shows a register-user example where `verify` lies, then refactors to an in-memory fake
- Closes by referencing the Mock 101 workshop + Lean Mind recap (so the original article stays linked as source)
- `talks.ts` — `articleUrl` is now `Record<Lang, string>` pointing at the internal post
- Talk card title now links to this new article instead of opening Lean Mind externally

## Test plan
- [ ] `/blog/strict-mocks-vs-fakes` y `/en/blog/strict-mocks-vs-fakes` renderizan OK, light/dark
- [ ] La card de Mock 101 en home (ES y EN) abre el post interno
- [ ] El link al repo `Sstark97/mock-101` y el link a Lean Mind dentro del post funcionan
- [ ] Mobile look OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)