### PR TITLE
fix(cv): skill card titles use #151b27 in light mode (#38)

### DIFF
--- a/src/components/cv/CvSkillCategory.astro
+++ b/src/components/cv/CvSkillCategory.astro
@@ -12,7 +12,7 @@ const { category } = Astro.props;
 <div class="reveal-fade group relative rounded-xl p-4 border border-secondary/15 bg-slate-50/30 dark:border-accent-violet/20 dark:bg-ink-800 hover:border-secondary/30 dark:hover:border-accent-violet/40 dark:hover:shadow-[0_0_30px_rgba(167,139,250,0.15)] transition-all duration-300">
   <div class="flex items-center gap-3 mb-3">
     <div class="h-2.5 w-2.5 rounded-full bg-secondary/30 dark:bg-accent-violet/50 border border-secondary/40 dark:border-accent-violet/60 shrink-0 group-hover:dark:bg-accent-violet/70 group-hover:dark:border-accent-violet/80 transition-colors"></div>
-    <h3 class="font-display font-bold text-base text-secondary dark:text-slate-100 tracking-tight">{category.name}</h3>
+    <h3 class="font-display font-bold text-base text-primary dark:text-slate-100 tracking-tight">{category.name}</h3>
   </div>
   <div class="flex flex-wrap gap-1.5">
     {category.skills.map((skill) => (


### PR DESCRIPTION
## Summary
- `CvSkillCategory.astro` — light-mode title color swapped from `text-secondary` (`#5e3aee`) to `text-primary` (`#151b27`)
- Dark mode unchanged (`text-slate-100`)
- PDF output unchanged (uses `CvPrintLayout.astro` with its own `.skill-cat` styling)

Closes #38

## Test plan
- [ ] `/cv` en light muestra los títulos ("Fundamentos de Ingeniería", "Backend", ...) en `#151b27`
- [ ] `/cv` en dark sigue mostrando los títulos blancos
- [ ] PDF descargable sin cambios visuales

🤖 Generated with [Claude Code](https://claude.com/claude-code)