### PR TITLE
fix(home): center talks grid when row is not full (#39)

### DIFF
--- a/src/components/home/Talks.astro
+++ b/src/components/home/Talks.astro
@@ -12,6 +12,13 @@ const { lang } = Astro.props;
 
 const locale = lang === 'en' ? 'en-US' : 'es-ES';
 const sorted = [...talks].sort((a, b) => (a.date < b.date ? 1 : -1));
+const isSingle = sorted.length === 1;
+const listClass = isSingle
+  ? 'mt-14 flex justify-center'
+  : 'mt-14 flex flex-wrap justify-center gap-5';
+const itemSizingClass = isSingle
+  ? 'w-full max-w-md'
+  : 'basis-full sm:basis-[calc((100%-1.25rem)/2)] lg:basis-[calc((100%-2.5rem)/3)]';
 ---
 
 <section
@@ -32,14 +39,17 @@ const sorted = [...talks].sort((a, b) => (a.date < b.date ? 1 : -1));
     </p>
 
     <ul
-      class="mt-14 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3"
+      class={listClass}
       data-stagger-root
     >
       {sorted.map((talk, i) => {
         const articleUrl = talk.articleUrl?.[lang];
         return (
         <li
-          class="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white p-6 shadow-lg backdrop-blur-md transition-[border-color,box-shadow,background-color] duration-500 hover:border-secondary/40 hover:shadow-[0_20px_50px_-20px_rgba(94,58,238,0.35)] dark:border-white/10 dark:bg-white/[0.04] dark:shadow-2xl dark:hover:border-accent-blue/40 dark:hover:bg-white/[0.07] dark:hover:shadow-[0_0_60px_rgba(96,165,250,0.15)]"
+          class:list={[
+            'group relative overflow-hidden rounded-2xl border border-slate-200 bg-white p-6 shadow-lg backdrop-blur-md transition-[border-color,box-shadow,background-color] duration-500 hover:border-secondary/40 hover:shadow-[0_20px_50px_-20px_rgba(94,58,238,0.35)] dark:border-white/10 dark:bg-white/[0.04] dark:shadow-2xl dark:hover:border-accent-blue/40 dark:hover:bg-white/[0.07] dark:hover:shadow-[0_0_60px_rgba(96,165,250,0.15)]',
+            itemSizingClass,
+          ]}
           data-stagger-item
           data-tilt-card
           style={`--stagger-delay:${i * 120}ms`}


### PR DESCRIPTION
## Summary
- Replaces the fixed `grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3` layout with `flex flex-wrap justify-center gap-5`
- Each card keeps its previous width at `sm` (1/2) and `lg` (1/3) via `basis-[calc(...)]`, so rows match the old visual — but the **last row now centers** whatever remainder it has
- Singleton case: flex container without wrap, card uses `w-full max-w-md` → visibly wider and centered, per the issue

## Behaviour
| Count | Mobile | sm | lg |
| --- | --- | --- | --- |
| 1 | full width, centered | wider (`max-w-md`), centered | wider, centered |
| 2 | stacked | side by side, centered | side by side (2/3 used), centered |
| 3 | stacked | 2 top / 1 centered | full 3-column row |
| 4 | — | 2 + 2 | 3 top / 1 centered |

Closes #39

## Follow-ups
Next step (per issue): open separate issues to apply the same rule to home `LatestPosts`, the blog listing, and the katas listing.

## Test plan
- [ ] Home ES/EN: la única card (Mock 101) aparece más ancha y centrada en light y dark
- [ ] Redimensionando → sigue centrada en todos los breakpoints
- [ ] Añadir un talk mental a `talks.ts` para comprobar que 2 quedan centradas y 3 ocupan el ancho (test manual opcional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)