### PR TITLE
fix(home): center LatestPosts grid when row is not full (#44)

### DIFF
--- a/src/components/home/LatestPosts.astro
+++ b/src/components/home/LatestPosts.astro
@@ -24,6 +24,14 @@ const posts = sortPostsByDate(filterDrafts(all))
   .filter((post) => post.id.startsWith(`${lang}/`))
   .slice(0, 3);
 
+const isSingle = posts.length === 1;
+const listClass = isSingle
+  ? 'mt-14 flex justify-center'
+  : 'mt-14 flex flex-wrap justify-center gap-6';
+const itemSizingClass = isSingle
+  ? 'w-full max-w-md'
+  : 'basis-full sm:basis-[calc((100%-1.5rem)/2)] lg:basis-[calc((100%-3rem)/3)]';
+
 ---
 
 <section
@@ -45,10 +53,10 @@ const posts = sortPostsByDate(filterDrafts(all))
 
     {
       posts.length > 0 ? (
-        <div class="mt-14 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <div class={listClass}>
           {posts.map((post, i) => (
             <div
-              class="home-post-wrapper"
+              class:list={['home-post-wrapper', itemSizingClass]}
               data-stagger-item
               style={`--stagger-delay:${i * 120}ms`}
             >


### PR DESCRIPTION
## Summary
Mirrors #43 for the home \"Últimos del blog\" section.
- `grid sm:grid-cols-2 lg:grid-cols-3` → `flex flex-wrap justify-center gap-6`
- Cards keep prior widths at sm (1/2) / lg (1/3) via `basis-[calc(...)]`
- Singleton renders `w-full max-w-md`, centered

Closes #44

## Test plan
- [ ] Home ES/EN: con 3 posts se ve igual que antes
- [ ] Simulando 2 posts → centrados
- [ ] Simulando 1 post → wider + centrado
- [ ] Light + dark OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)