### PR TITLE
fix(katas): center katas grid and remainder rows after filtering (#46)

### DIFF
--- a/src/components/katas/KataCard.astro
+++ b/src/components/katas/KataCard.astro
@@ -19,7 +19,7 @@ const formattedDate = new Date(kata.date).toLocaleDateString(dateLocale, {
 ---
 
 <article
-  class="kata-card reveal-fade group relative flex flex-col gap-4 overflow-hidden rounded-2xl border border-slate-200 bg-white p-6 shadow-lg backdrop-blur-md transition-[border-color,box-shadow,background-color] duration-500 hover:border-secondary/40 hover:shadow-[0_20px_50px_-20px_rgba(94,58,238,0.35)] dark:border-white/10 dark:bg-white/[0.04] dark:shadow-2xl dark:hover:border-accent-blue/40 dark:hover:bg-white/[0.07] dark:hover:shadow-[0_0_60px_rgba(96,165,250,0.15)]"
+  class="kata-card reveal-fade group relative flex flex-col gap-4 overflow-hidden rounded-2xl border border-slate-200 bg-white p-6 shadow-lg backdrop-blur-md transition-[border-color,box-shadow,background-color] duration-500 hover:border-secondary/40 hover:shadow-[0_20px_50px_-20px_rgba(94,58,238,0.35)] dark:border-white/10 dark:bg-white/[0.04] dark:shadow-2xl dark:hover:border-accent-blue/40 dark:hover:bg-white/[0.07] dark:hover:shadow-[0_0_60px_rgba(96,165,250,0.15)] basis-full sm:basis-[calc((100%-1.25rem)/2)] lg:basis-[calc((100%-2.5rem)/3)]"
   data-kata-card
   data-tech={kata.tech.join('|')}
 >

--- a/src/components/katas/KatasPage.astro
+++ b/src/components/katas/KatasPage.astro
@@ -73,7 +73,7 @@ const techs = [...techFrequency.entries()]
       ))}
     </div>
 
-    <div class="reveal-group grid gap-5 sm:grid-cols-2 lg:grid-cols-3" data-kata-grid>
+    <div class="reveal-group flex flex-wrap justify-center gap-5" data-kata-grid>
       {sorted.map((kata) => <KataCard kata={kata} lang={lang} />)}
     </div>
 


### PR DESCRIPTION
## Summary
Applies the #43 / #47 / #48 pattern to the katas listing.
- Container: `grid sm:grid-cols-2 lg:grid-cols-3` → `flex flex-wrap justify-center gap-5`
- Widths moved onto the `<article data-kata-card>` via `basis-[calc(...)]`
- Filter-hidden cards already use `display: none` via the existing global CSS, so flex flow skips them entirely and `justify-center` naturally centers the remainder rows. No JS changes needed.

## Note on singleton behaviour
Not special-casing `sorted.length === 1` here (total katas is 10+). The spec's wider-singleton rule was for sections that can realistically hold 1 item; if a filter yields exactly 1 visible kata, it stays at 1/3 width and centered, which matches the current visual language of the listing.

Closes #46

## Test plan
- [ ] `/katas` y `/en/katas` con filtro "Todas" se ve igual que antes
- [ ] Filtrar por una tech que solo aparezca en 1-2 katas → visibles quedan centradas
- [ ] Última fila con remainder (e.g. 10 visibles → 3 + 3 + 3 + 1) → fila final centrada
- [ ] Empty-state (filtro sin matches) sigue renderizando su mensaje
- [ ] Light + dark OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)