### PR TITLE
refactor(blog): use Button atom for back-to-blog link

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -39,6 +39,7 @@ import CodeBlockEnhancer from '../../components/blog/CodeBlockEnhancer.astro';
 import { calculateReadingTime } from '../../lib/blog';
 import { formatDate, formatDateISO } from '../../lib/date';
 import DotField from '../../components/atoms/DotField.astro';
+import Button from '../../components/atoms/Button.astro';
 import { t, getBlogSlugFromId } from '../../i18n/utils';
 
 const lang = 'es';
@@ -287,23 +288,20 @@ const coverImageAbsolute = toAbsoluteUrl(coverImageUrl);
         </div>
 
         <!-- Back to Blog Link -->
-        <a
-          href="/blog"
-          class="inline-flex items-center gap-2 rounded-full bg-slate-100 dark:bg-slate-700 px-4 py-2 text-sm font-mono uppercase tracking-[0.15em] text-slate-700 dark:text-slate-300 transition-colors hover:bg-slate-200 dark:hover:bg-slate-600"
-        >
+        <Button href="/blog" tone="blue">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
-            stroke-width="1.5"
+            stroke-width="2"
             stroke="currentColor"
-            class="w-4 h-4"
+            class="h-4 w-4 transition-transform group-hover:-translate-x-0.5"
             aria-hidden="true"
           >
             <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
           </svg>
-          {t(lang, 'blog.backToBlog')}
-        </a>
+          <span>{t(lang, 'blog.backToBlog')}</span>
+        </Button>
       </div>
     </footer>
 

--- a/src/pages/en/blog/[...slug].astro
+++ b/src/pages/en/blog/[...slug].astro
@@ -9,6 +9,7 @@ import CodeBlockEnhancer from '../../../components/blog/CodeBlockEnhancer.astro'
 import { calculateReadingTime } from '../../../lib/blog';
 import { formatDate, formatDateISO } from '../../../lib/date';
 import DotField from '../../../components/atoms/DotField.astro';
+import Button from '../../../components/atoms/Button.astro';
 import { t, getBlogSlugFromId } from '../../../i18n/utils';
 
 const lang = 'en';
@@ -221,15 +222,12 @@ const coverImageAbsolute = toAbsoluteUrl(coverImageUrl);
             </p>
           </div>
         </div>
-        <a
-          href="/en/blog"
-          class="inline-flex items-center gap-2 rounded-full bg-slate-100 dark:bg-slate-700 px-4 py-2 text-sm font-mono uppercase tracking-[0.15em] text-slate-700 dark:text-slate-300 transition-colors hover:bg-slate-200 dark:hover:bg-slate-600"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4" aria-hidden="true">
+        <Button href="/en/blog" tone="blue">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="h-4 w-4 transition-transform group-hover:-translate-x-0.5" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
           </svg>
-          {t(lang, 'blog.backToBlog')}
-        </a>
+          <span>{t(lang, 'blog.backToBlog')}</span>
+        </Button>
       </div>
     </footer>
 


### PR DESCRIPTION
## Summary
- The back link in article footers was an ad-hoc rounded-full slate button, inconsistent with every other CTA in the app
- Swaps for `<Button tone=\"blue\">` from the shared atom so the design system covers this nav as well
- Arrow icon slides slightly left on hover (`group-hover:-translate-x-0.5`) for direction hinting

## Test plan
- [x] `npm run build` — 0 errors
- [ ] Manual: open any article in ES and EN, click the back button, confirm styling matches the blog-listing closing CTA buttons
- [ ] Manual: light + dark mode both coherent

🤖 Generated with [Claude Code](https://claude.com/claude-code)