### PR TITLE
fix(home): eliminar efecto tilt de cards de Charlas

### DIFF
--- a/src/components/home/Talks.astro
+++ b/src/components/home/Talks.astro
@@ -51,7 +51,6 @@ const itemSizingClass = isSingle
             itemSizingClass,
           ]}
           data-stagger-item
-          data-tilt-card
           style={`--stagger-delay:${i * 120}ms`}
         >
           <div


### PR DESCRIPTION
## Summary
- Elimina el atributo `data-tilt-card` de las cards de la sección Charlas en la home, para que ya no se inclinen/muevan al pasar el ratón.
- El movimiento confundía la interacción al hacer clic sobre la card y sobre el enlace al repo.

Closes #54

## Test plan
- [ ] Cargar la home y pasar el ratón sobre las cards de Charlas: no deben inclinarse ni elevarse.
- [ ] El hover sigue mostrando el cambio de borde/sombra y el clic en la card o en el enlace al repo funciona correctamente.
- [ ] Otras secciones con tilt (Portfolio, WhatIDo, StatsCounter) conservan su efecto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)