### PR TITLE
fix(cv): el enlace de email en el CV apunta al formulario

### DIFF
--- a/src/components/cv/CvHeader.astro
+++ b/src/components/cv/CvHeader.astro
@@ -1,12 +1,15 @@
 ---
 import { Icon } from 'astro-icon/components';
 import type { ContactInfo } from '../../data/cv';
+import { getLangFromUrl, getLocalePath } from '../../i18n/utils';
 
 interface Props {
   contact: ContactInfo;
 }
 
 const { contact } = Astro.props;
+const lang = getLangFromUrl(Astro.url);
+const contactHref = `${getLocalePath('/', lang)}#contact`;
 ---
 
 <header class="relative text-center mb-10 md:mb-14 pt-4 md:pt-6">
@@ -41,17 +44,20 @@ const { contact } = Astro.props;
       <Icon name="location" class="w-3.5 h-3.5" />
       {contact.location}
     </span>
-    {contact.links.map((link) => (
-      <a
-        href={link.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="flex items-center gap-1.5 hover:text-secondary dark:hover:text-accent-blue transition ease-linear duration-200"
-      >
-        <Icon name={link.icon} class="w-3.5 h-3.5" />
-        {link.label}
-      </a>
-    ))}
+    {contact.links.map((link) => {
+      const isMail = link.url.startsWith('mailto:');
+      const href = isMail ? contactHref : link.url;
+      return (
+        <a
+          href={href}
+          {...(isMail ? {} : { target: '_blank', rel: 'noopener noreferrer' })}
+          class="flex items-center gap-1.5 hover:text-secondary dark:hover:text-accent-blue transition ease-linear duration-200"
+        >
+          <Icon name={link.icon} class="w-3.5 h-3.5" />
+          {link.label}
+        </a>
+      );
+    })}
   </div>
 
   <!-- Decorative accent line -->


### PR DESCRIPTION
## Summary
- En el header del CV (`CvHeader.astro`), el enlace `info@aitorevi.dev` seguía siendo un `mailto:` que abría el gestor de correo del usuario.
- Ahora, de forma consistente con el Footer y el CTA de katas (ver #40 / commit 121d8a0), ese enlace redirige al formulario de contacto (`/#contact` o `/en/#contact` según idioma).
- La salida PDF/ATS no cambia: `CvPrintLayout.astro` renderiza los contactos como texto plano.

## Test plan
- [ ] Visitar `/cv` y `/en/cv` en el navegador y hacer clic en el icono de sobre junto al email: debe hacer scroll al formulario de contacto, no abrir el cliente de correo.
- [ ] LinkedIn y GitHub siguen abriéndose en nueva pestaña con `rel="noopener noreferrer"`.
- [ ] Los PDFs regenerados (`aitor-reviriego-cv-ats-es.pdf` / `-en.pdf`) siguen mostrando el email como texto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)