### PR TITLE
ci: keep-alive cron para Upstash Redis

### DIFF
--- a/.github/workflows/keep-alive-upstash.yml
+++ b/.github/workflows/keep-alive-upstash.yml
@@ -1,0 +1,19 @@
+name: Keep Upstash Redis Alive
+
+on:
+  schedule:
+    - cron: '0 9 * * 1,4' # Mondays and Thursdays at 09:00 UTC
+  workflow_dispatch:
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Upstash Redis via REST
+        run: |
+          curl --fail --silent --show-error \
+            -H "Authorization: Bearer $UPSTASH_REDIS_REST_TOKEN" \
+            "$UPSTASH_REDIS_REST_URL/ping" > /dev/null
+        env:
+          UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+          UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}


### PR DESCRIPTION
## Summary
- Añade un workflow programado (`.github/workflows/keep-alive-upstash.yml`) que hace `curl` a `/ping` de Upstash Redis REST los lunes y jueves a las 09:00 UTC.
- Resuelve el aviso de Upstash de que `redis-aitorevi-dev` lleva semanas sin tráfico y está en cola para archivar.
- Mismo patrón que el keep-alive de Supabase del proyecto IMS.

Closes #57

## Requisitos (fuera del código)
> Antes de confiar en el cron hay que crear dos secrets de repo con los mismos valores que tiene Vercel:
> - `UPSTASH_REDIS_REST_URL`
> - `UPSTASH_REDIS_REST_TOKEN`

`gh secret set UPSTASH_REDIS_REST_URL --repo aitorevi/aitorevi-blog`
`gh secret set UPSTASH_REDIS_REST_TOKEN --repo aitorevi/aitorevi-blog`

## Test plan
- [ ] Crear los dos secrets arriba indicados.
- [ ] Lanzar el workflow a mano desde la pestaña Actions (`workflow_dispatch`) y verificar que termina en verde.
- [ ] Comprobar en la consola de Upstash que el tráfico registrado coincide con la hora de ejecución.

🤖 Generated with [Claude Code](https://claude.com/claude-code)