### PR TITLE
feat(analytics): Google Analytics 4 + Search Console

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,10 @@ PUBLIC_KEYSTATIC_GITHUB_APP_SLUG=
 KEYSTATIC_GITHUB_CLIENT_ID=
 KEYSTATIC_GITHUB_CLIENT_SECRET=
 KEYSTATIC_SECRET=
+
+# Google Analytics 4 — measurement ID (G-XXXXXXX). Si no se define, GA no se carga.
+PUBLIC_GA4_MEASUREMENT_ID=
+
+# Google Search Console — valor del meta tag de verificación.
+# GSC → Settings → Ownership verification → HTML tag → copiar solo el content.
+PUBLIC_GSC_VERIFICATION=

--- a/src/components/analytics/GoogleAnalytics.astro
+++ b/src/components/analytics/GoogleAnalytics.astro
@@ -1,0 +1,35 @@
+---
+const id = import.meta.env.PUBLIC_GA4_MEASUREMENT_ID;
+const path = Astro.url.pathname;
+const isExcluded = path.includes('/print') || path.startsWith('/keystatic');
+const shouldLoad = Boolean(id) && !isExcluded;
+---
+{shouldLoad && (
+  <>
+    <script async src={`https://www.googletagmanager.com/gtag/js?id=${id}`}></script>
+    <script is:inline define:vars={{ id }}>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){ dataLayer.push(arguments); }
+      window.gtag = gtag;
+
+      gtag('consent', 'default', {
+        analytics_storage: 'granted',
+        ad_storage: 'denied',
+        ad_user_data: 'denied',
+        ad_personalization: 'denied',
+      });
+
+      gtag('js', new Date());
+      gtag('config', id, { send_page_view: false, anonymize_ip: true });
+
+      function trackPageView() {
+        gtag('event', 'page_view', {
+          page_title: document.title,
+          page_location: window.location.href,
+          page_path: window.location.pathname + window.location.search,
+        });
+      }
+      document.addEventListener('astro:page-load', trackPageView);
+    </script>
+  </>
+)}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import { ClientRouter } from 'astro:transitions';
 import Analytics from '@vercel/analytics/astro';
+import GoogleAnalytics from '../components/analytics/GoogleAnalytics.astro';
 import Nav from "../components/Nav/Nav.astro";
 import Footer from "../components/Footer/Footer.astro";
 import { getLangFromUrl, getAlternateUrl, t } from '../i18n/utils';
@@ -76,7 +77,11 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `https://www.aitorevi.
 			})();
 		</script>
 		<ClientRouter />
+		{import.meta.env.PUBLIC_GSC_VERIFICATION && (
+			<meta name="google-site-verification" content={import.meta.env.PUBLIC_GSC_VERIFICATION} />
+		)}
 		<slot name="head" />
+		<GoogleAnalytics />
 	</head>
 	<body
 		class="flex flex-col min-h-dvh bg-white dark:bg-[#0f1419] text-primary dark:text-[#f1f5f9] scrollbar scrollbar-thumb-primary scrollbar-w-2 scrollbar-corner-rounded-xl"


### PR DESCRIPTION
## Summary
- Añade integración de **Google Analytics 4** vía `gtag.js` cargado condicionalmente (`PUBLIC_GA4_MEASUREMENT_ID`).
- Añade verificación de **Google Search Console** vía `<meta name=\"google-site-verification\">` (`PUBLIC_GSC_VERIFICATION`).
- Mantiene Vercel Analytics: da Web Vitals que GA4 no expone nativamente.

## Detalles técnicos
- Nuevo componente `src/components/analytics/GoogleAnalytics.astro` que:
  - Solo renderiza si la var está definida → dev sin configurar = 0 hits.
  - Excluye `/print` y `/keystatic` → no contamina Puppeteer (PDF del CV) ni el admin.
  - Desactiva `send_page_view` y dispara `page_view` manualmente en `astro:page-load` → compatible con view transitions, sin doble hit.
  - `anonymize_ip: true` y defaults de \`ad_*\` en \`denied\` para reducir superficie RGPD hasta tener el banner de consent.
- Layout: meta de GSC + `<GoogleAnalytics />` dentro del \`<head>\`.
- `.env.example` documenta ambas vars.

## RGPD — follow-up
Este PR **no** incluye banner de consent ni política de privacidad. Ambos tracked en:
- Related: #59 — Cookie consent banner + Consent Mode v2
- Related: #60 — Página de Política de Privacidad

Se abordarán antes de promocionar el site públicamente.

## Test plan
- [x] \`npm run build\` verde.
- [x] \`npm test\` — 127/127 tests verdes.
- [ ] Setear \`PUBLIC_GA4_MEASUREMENT_ID\` y \`PUBLIC_GSC_VERIFICATION\` en Vercel (Production + Preview) y redeploy.
- [ ] GA4 → Reports → Realtime: navegar home → /blog → post → /cv con view transitions y confirmar un \`page_view\` por ruta, sin duplicados.
- [ ] DevTools → Network → filtro \`collect\`: un hit por navegación.
- [ ] GSC → Verify propiedad \`https://www.aitorevi.dev\` → \"Verified\".
- [ ] GSC → Submit sitemap \`https://www.aitorevi.dev/sitemap-index.xml\` → \"Success\".
- [ ] Abrir \`/cv/print/\` en prod: no debe cargar el script de GA (ver DevTools → Network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)