### PR TITLE
feat(legal): Privacidad, Cookies y Aviso Legal (es/en)

### DIFF
--- a/src/components/Footer/Footer.astro
+++ b/src/components/Footer/Footer.astro
@@ -5,6 +5,18 @@ import { getLangFromUrl, getLocalePath } from '../../i18n/utils';
 const lang = getLangFromUrl(Astro.url);
 const isES = lang === 'es';
 const contactHref = `${getLocalePath('/', lang)}#contact`;
+
+const legalLinks = isES
+    ? [
+        { label: 'Privacidad', href: '/privacidad' },
+        { label: 'Cookies', href: '/cookies' },
+        { label: 'Aviso Legal', href: '/aviso-legal' },
+      ]
+    : [
+        { label: 'Privacy', href: '/en/privacy' },
+        { label: 'Cookies', href: '/en/cookies' },
+        { label: 'Legal Notice', href: '/en/legal-notice' },
+      ];
 ---
 <footer class="relative flex flex-col w-full items-center justify-center gap-2 py-5 md:py-6 bg-white/90 dark:bg-ink-800/60 backdrop-blur-md border-t border-gray-200 dark:border-white/10 transition-colors duration-200">
     <div class="flex items-center justify-center gap-8">
@@ -21,4 +33,14 @@ const contactHref = `${getLocalePath('/', lang)}#contact`;
     <p class="font-mono text-[10px] uppercase tracking-[0.2em] text-quaternary/70 dark:text-slate-500">
         &copy; {new Date().getFullYear()} aitorevi · Crafted with Astro
     </p>
+    <nav class="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 font-mono text-[10px] uppercase tracking-[0.2em] text-quaternary/70 dark:text-slate-500" aria-label={isES ? 'Enlaces legales' : 'Legal links'}>
+        {legalLinks.map((link, i) => (
+            <>
+                {i > 0 && <span aria-hidden="true">·</span>}
+                <a href={link.href} class="hover:text-secondary dark:hover:text-accent-blue transition-colors duration-200">
+                    {link.label}
+                </a>
+            </>
+        ))}
+    </nav>
 </footer>

--- a/src/components/legal/LegalPageLayout.astro
+++ b/src/components/legal/LegalPageLayout.astro
@@ -1,0 +1,34 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import type { Lang } from '../../data/cv';
+
+interface Props {
+  title: string;
+  description: string;
+  lang: Lang;
+  updatedDate: string;
+}
+
+const { title, description, lang, updatedDate } = Astro.props;
+const updatedLabel = lang === 'es' ? 'Última actualización' : 'Last updated';
+---
+
+<Layout title={`${title} · aitorevi.dev`} description={description} lang={lang} variant="dark-radial">
+  <section class="mx-auto max-w-3xl px-6 pt-24 pb-16 md:pt-32 md:pb-24">
+    <header class="mb-10 border-b border-slate-200 dark:border-white/10 pb-6">
+      <p class="font-mono text-[10px] md:text-[11px] uppercase tracking-[0.35em] text-accent-violet/70 dark:text-accent-violet/80 mb-3">
+        — {lang === 'es' ? 'Información legal' : 'Legal'} —
+      </p>
+      <h1 class="font-display text-3xl md:text-5xl font-bold tracking-tight text-ink-900 dark:text-slate-100">
+        {title}
+      </h1>
+      <p class="mt-3 text-sm text-slate-500 dark:text-slate-400">
+        {updatedLabel}: <time datetime={updatedDate}>{updatedDate}</time>
+      </p>
+    </header>
+
+    <article class="prose prose-slate dark:prose-invert max-w-none prose-headings:font-display prose-headings:tracking-tight prose-h2:text-xl prose-h2:mt-10 prose-h2:mb-3 prose-h3:text-base prose-h3:mt-6 prose-h3:mb-2 prose-a:text-secondary dark:prose-a:text-accent-blue hover:prose-a:text-accent-violet">
+      <slot />
+    </article>
+  </section>
+</Layout>

--- a/src/pages/aviso-legal.astro
+++ b/src/pages/aviso-legal.astro
@@ -1,0 +1,76 @@
+---
+import LegalPageLayout from '../components/legal/LegalPageLayout.astro';
+---
+
+<LegalPageLayout
+  lang="es"
+  title="Aviso Legal"
+  description="Información legal del sitio web aitorevi.dev en cumplimiento de la Ley 34/2002 (LSSI-CE)."
+  updatedDate="2026-04-22"
+>
+  <p>
+    Este aviso legal regula el uso del sitio web <strong>aitorevi.dev</strong> en
+    cumplimiento del artículo 10 de la Ley 34/2002, de Servicios de la Sociedad de la
+    Información y de Comercio Electrónico (LSSI-CE).
+  </p>
+
+  <h2>1. Titular del sitio</h2>
+  <ul>
+    <li><strong>Nombre:</strong> Aitor Reviriego Amor.</li>
+    <li><strong>Actividad:</strong> blog personal sobre desarrollo de software, sin fin comercial directo.</li>
+    <li><strong>Email de contacto:</strong> <a href="mailto:info@aitorevi.dev">info@aitorevi.dev</a>.</li>
+  </ul>
+
+  <h2>2. Condiciones de uso</h2>
+  <p>
+    El acceso al sitio es libre y gratuito. Al navegar por él aceptas las condiciones
+    descritas en este aviso y en las políticas que lo complementan
+    (<a href="/privacidad">Privacidad</a> y <a href="/cookies">Cookies</a>).
+  </p>
+  <p>
+    Te comprometes a hacer un uso lícito del sitio, sin atentar contra su funcionamiento,
+    los derechos del titular o de terceros. Está prohibido el envío de contenido ilícito,
+    ofensivo o malicioso a través del formulario de contacto.
+  </p>
+
+  <h2>3. Propiedad intelectual</h2>
+  <p>
+    Los contenidos originales del blog (textos, imágenes propias, diseño y código fuente
+    del site) pertenecen a Aitor Reviriego Amor salvo indicación expresa. Se permite su
+    lectura y citación con atribución y enlace al original.
+  </p>
+  <p>
+    Las reproducciones sustanciales, traducciones o usos comerciales requieren autorización
+    previa por escrito. Los fragmentos de código publicados se ofrecen como ejemplo y
+    pueden reutilizarse libremente salvo que se especifique otra licencia en el propio
+    post o repositorio.
+  </p>
+
+  <h2>4. Enlaces a terceros</h2>
+  <p>
+    El sitio puede contener enlaces a páginas externas. No se asume responsabilidad
+    sobre su contenido, disponibilidad ni políticas de privacidad. La inclusión de un
+    enlace no implica recomendación ni relación comercial salvo que se diga explícitamente.
+  </p>
+
+  <h2>5. Exclusión de garantías y responsabilidad</h2>
+  <p>
+    El sitio se ofrece "tal cual", con la diligencia razonable esperable de un blog
+    personal. No se garantiza la ausencia de errores, interrupciones puntuales o
+    inexactitudes. El titular queda exento de responsabilidad por daños derivados del
+    uso del sitio siempre que haya actuado con dicha diligencia.
+  </p>
+
+  <h2>6. Modificaciones</h2>
+  <p>
+    El titular puede actualizar este aviso legal en cualquier momento. La fecha de última
+    actualización figura arriba. Los cambios sustanciales se anunciarán en el sitio.
+  </p>
+
+  <h2>7. Legislación aplicable y jurisdicción</h2>
+  <p>
+    Este aviso se rige por la legislación española. Para cualquier conflicto derivado del
+    uso del sitio serán competentes los juzgados y tribunales que correspondan según la
+    normativa vigente.
+  </p>
+</LegalPageLayout>

--- a/src/pages/cookies.astro
+++ b/src/pages/cookies.astro
@@ -1,0 +1,123 @@
+---
+import LegalPageLayout from '../components/legal/LegalPageLayout.astro';
+---
+
+<LegalPageLayout
+  lang="es"
+  title="Política de Cookies"
+  description="Qué cookies utiliza aitorevi.dev, con qué finalidad, durante cuánto tiempo y cómo puedes gestionarlas."
+  updatedDate="2026-04-22"
+>
+  <p>
+    Esta política complementa la <a href="/privacidad">Política de Privacidad</a> y explica
+    qué cookies utiliza <strong>aitorevi.dev</strong>, con qué finalidad y cómo puedes
+    gestionarlas o retirar tu consentimiento en cualquier momento.
+  </p>
+
+  <h2>1. Qué son las cookies</h2>
+  <p>
+    Una cookie es un pequeño fichero que un sitio web almacena en tu navegador para
+    recordar información entre páginas o visitas: preferencias, estado de sesión,
+    datos estadísticos, etc.
+  </p>
+
+  <h2>2. Tipos de cookies utilizadas</h2>
+  <p>Este sitio utiliza dos tipos:</p>
+  <ul>
+    <li>
+      <strong>Técnicas (necesarias)</strong>: imprescindibles para el funcionamiento
+      básico. No requieren consentimiento (art. 22.2 LSSI-CE).
+    </li>
+    <li>
+      <strong>Analíticas (de terceros)</strong>: miden el uso del sitio de forma agregada.
+      <strong>Solo se activan si has aceptado en el banner de cookies</strong>. Puedes
+      rechazarlas sin que se pierda funcionalidad.
+    </li>
+  </ul>
+  <p>No se utilizan cookies publicitarias, de marketing ni de perfilado.</p>
+
+  <h2>3. Detalle de cookies</h2>
+  <div class="not-prose overflow-x-auto my-6">
+    <table class="min-w-full text-sm border-collapse">
+      <thead>
+        <tr class="border-b border-slate-300 dark:border-white/20">
+          <th class="text-left py-2 px-3 font-semibold">Nombre</th>
+          <th class="text-left py-2 px-3 font-semibold">Titular</th>
+          <th class="text-left py-2 px-3 font-semibold">Finalidad</th>
+          <th class="text-left py-2 px-3 font-semibold">Tipo</th>
+          <th class="text-left py-2 px-3 font-semibold">Duración</th>
+        </tr>
+      </thead>
+      <tbody class="text-slate-600 dark:text-slate-300">
+        <tr class="border-b border-slate-200 dark:border-white/10">
+          <td class="py-2 px-3 font-mono text-xs">aitorevi_consent</td>
+          <td class="py-2 px-3">aitorevi.dev</td>
+          <td class="py-2 px-3">Recordar tu elección de consentimiento de cookies.</td>
+          <td class="py-2 px-3">Técnica · Propia</td>
+          <td class="py-2 px-3">1 año</td>
+        </tr>
+        <tr class="border-b border-slate-200 dark:border-white/10">
+          <td class="py-2 px-3 font-mono text-xs">_ga</td>
+          <td class="py-2 px-3">Google LLC</td>
+          <td class="py-2 px-3">Identificar de forma anónima usuarios únicos en Google Analytics 4.</td>
+          <td class="py-2 px-3">Analítica · Terceros</td>
+          <td class="py-2 px-3">2 años</td>
+        </tr>
+        <tr>
+          <td class="py-2 px-3 font-mono text-xs">_ga_&lt;ID&gt;</td>
+          <td class="py-2 px-3">Google LLC</td>
+          <td class="py-2 px-3">Persistir el estado de sesión de Google Analytics 4.</td>
+          <td class="py-2 px-3">Analítica · Terceros</td>
+          <td class="py-2 px-3">2 años</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <p>
+    Vercel (hosting y Web Vitals) no instala cookies persistentes identificables; los
+    Web Vitals se recogen de forma anónima y agregada.
+  </p>
+
+  <h2>4. Base legal</h2>
+  <ul>
+    <li><strong>Cookies técnicas</strong>: interés legítimo (art. 6.1.f RGPD) y exclusión del consentimiento (art. 22.2 LSSI-CE).</li>
+    <li><strong>Cookies analíticas</strong>: consentimiento explícito a través del banner (art. 6.1.a RGPD y art. 22.2 LSSI-CE).</li>
+  </ul>
+
+  <h2>5. Cómo gestionar o retirar el consentimiento</h2>
+  <p>Puedes cambiar tu elección en cualquier momento por estas vías:</p>
+  <ul>
+    <li>
+      <strong>En el sitio</strong>: pulsa "Gestionar cookies" en el pie de página para
+      reabrir el banner y cambiar tu elección.
+    </li>
+    <li>
+      <strong>Desde el navegador</strong>: elimina la cookie <code>aitorevi_consent</code>
+      (y `_ga*` si quieres limpiar también la analítica) y la próxima visita volverá a
+      mostrar el banner.
+    </li>
+    <li>
+      <strong>Opt-out de Google Analytics</strong>: instala el complemento oficial
+      <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer">Google Analytics Opt-out</a>
+      en tu navegador.
+    </li>
+    <li>
+      <strong>Por navegador</strong>: cada navegador tiene su propio panel para listar
+      y borrar cookies (Chrome, Firefox, Safari, Edge, etc.).
+    </li>
+  </ul>
+
+  <h2>6. Transferencias internacionales</h2>
+  <p>
+    Las cookies de Google Analytics implican transferencia de datos a EE. UU., cubierta
+    por las Cláusulas Contractuales Tipo aprobadas por la Comisión Europea. Más detalle
+    en la <a href="/privacidad">Política de Privacidad</a>.
+  </p>
+
+  <h2>7. Cambios en esta política</h2>
+  <p>
+    Si cambian las herramientas que usa el sitio, esta política se actualizará y verás
+    reflejada la nueva fecha al inicio de la página. Los cambios sustanciales te pedirán
+    consentimiento de nuevo mediante el banner.
+  </p>
+</LegalPageLayout>

--- a/src/pages/en/cookies.astro
+++ b/src/pages/en/cookies.astro
@@ -1,0 +1,122 @@
+---
+import LegalPageLayout from '../../components/legal/LegalPageLayout.astro';
+---
+
+<LegalPageLayout
+  lang="en"
+  title="Cookie Policy"
+  description="Cookies used by aitorevi.dev: what they are, their purpose, retention, and how to manage or withdraw your consent."
+  updatedDate="2026-04-22"
+>
+  <p>
+    This policy complements the <a href="/en/privacy">Privacy Policy</a> and explains which
+    cookies <strong>aitorevi.dev</strong> uses, for what purpose, and how you can manage
+    them or withdraw your consent at any time.
+  </p>
+
+  <h2>1. What are cookies</h2>
+  <p>
+    A cookie is a small file a website stores in your browser to remember information
+    across pages or visits: preferences, session state, statistical data, etc.
+  </p>
+
+  <h2>2. Types of cookies used</h2>
+  <p>This site uses two types:</p>
+  <ul>
+    <li>
+      <strong>Technical (necessary)</strong>: essential for basic functionality. No
+      consent required (Spanish LSSI-CE art. 22.2).
+    </li>
+    <li>
+      <strong>Analytics (third-party)</strong>: measure site usage in aggregate form.
+      <strong>Only active if you accepted via the cookie banner</strong>. You can reject
+      them without losing functionality.
+    </li>
+  </ul>
+  <p>No advertising, marketing or profiling cookies are used.</p>
+
+  <h2>3. Cookie details</h2>
+  <div class="not-prose overflow-x-auto my-6">
+    <table class="min-w-full text-sm border-collapse">
+      <thead>
+        <tr class="border-b border-slate-300 dark:border-white/20">
+          <th class="text-left py-2 px-3 font-semibold">Name</th>
+          <th class="text-left py-2 px-3 font-semibold">Owner</th>
+          <th class="text-left py-2 px-3 font-semibold">Purpose</th>
+          <th class="text-left py-2 px-3 font-semibold">Type</th>
+          <th class="text-left py-2 px-3 font-semibold">Retention</th>
+        </tr>
+      </thead>
+      <tbody class="text-slate-600 dark:text-slate-300">
+        <tr class="border-b border-slate-200 dark:border-white/10">
+          <td class="py-2 px-3 font-mono text-xs">aitorevi_consent</td>
+          <td class="py-2 px-3">aitorevi.dev</td>
+          <td class="py-2 px-3">Remember your cookie consent choice.</td>
+          <td class="py-2 px-3">Technical · First-party</td>
+          <td class="py-2 px-3">1 year</td>
+        </tr>
+        <tr class="border-b border-slate-200 dark:border-white/10">
+          <td class="py-2 px-3 font-mono text-xs">_ga</td>
+          <td class="py-2 px-3">Google LLC</td>
+          <td class="py-2 px-3">Anonymously identify unique users in Google Analytics 4.</td>
+          <td class="py-2 px-3">Analytics · Third-party</td>
+          <td class="py-2 px-3">2 years</td>
+        </tr>
+        <tr>
+          <td class="py-2 px-3 font-mono text-xs">_ga_&lt;ID&gt;</td>
+          <td class="py-2 px-3">Google LLC</td>
+          <td class="py-2 px-3">Persist Google Analytics 4 session state.</td>
+          <td class="py-2 px-3">Analytics · Third-party</td>
+          <td class="py-2 px-3">2 years</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <p>
+    Vercel (hosting and Web Vitals) does not install identifying persistent cookies;
+    Web Vitals are collected anonymously and in aggregate.
+  </p>
+
+  <h2>4. Legal basis</h2>
+  <ul>
+    <li><strong>Technical cookies</strong>: legitimate interest (GDPR art. 6.1.f) and consent exclusion (Spanish LSSI-CE art. 22.2).</li>
+    <li><strong>Analytics cookies</strong>: explicit consent via the banner (GDPR art. 6.1.a and LSSI-CE art. 22.2).</li>
+  </ul>
+
+  <h2>5. How to manage or withdraw consent</h2>
+  <p>You can change your choice at any time in any of these ways:</p>
+  <ul>
+    <li>
+      <strong>From the site</strong>: click "Manage cookies" in the footer to reopen the
+      banner and change your choice.
+    </li>
+    <li>
+      <strong>From your browser</strong>: delete the <code>aitorevi_consent</code> cookie
+      (and <code>_ga*</code> if you also want to clear analytics). The banner will show
+      again on your next visit.
+    </li>
+    <li>
+      <strong>Google Analytics opt-out</strong>: install the official
+      <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer">Google Analytics Opt-out</a>
+      browser add-on.
+    </li>
+    <li>
+      <strong>Per-browser settings</strong>: each browser has its own panel to list and
+      delete cookies (Chrome, Firefox, Safari, Edge, etc.).
+    </li>
+  </ul>
+
+  <h2>6. International transfers</h2>
+  <p>
+    Google Analytics cookies imply data transfer to the USA, covered by the Standard
+    Contractual Clauses approved by the European Commission. More detail in the
+    <a href="/en/privacy">Privacy Policy</a>.
+  </p>
+
+  <h2>7. Changes to this policy</h2>
+  <p>
+    If the tools used by the site change, this policy will be updated and the new date
+    will appear at the top. Substantial changes will prompt you for consent again via
+    the banner.
+  </p>
+</LegalPageLayout>

--- a/src/pages/en/legal-notice.astro
+++ b/src/pages/en/legal-notice.astro
@@ -1,0 +1,74 @@
+---
+import LegalPageLayout from '../../components/legal/LegalPageLayout.astro';
+---
+
+<LegalPageLayout
+  lang="en"
+  title="Legal Notice"
+  description="Legal notice for aitorevi.dev, pursuant to article 10 of Spanish Law 34/2002 (LSSI-CE)."
+  updatedDate="2026-04-22"
+>
+  <p>
+    This legal notice governs the use of <strong>aitorevi.dev</strong>, in compliance
+    with article 10 of Spanish Law 34/2002 on Information Society Services and Electronic
+    Commerce (LSSI-CE).
+  </p>
+
+  <h2>1. Site owner</h2>
+  <ul>
+    <li><strong>Name:</strong> Aitor Reviriego Amor.</li>
+    <li><strong>Activity:</strong> personal blog about software development, no direct commercial activity.</li>
+    <li><strong>Contact email:</strong> <a href="mailto:info@aitorevi.dev">info@aitorevi.dev</a>.</li>
+  </ul>
+
+  <h2>2. Terms of use</h2>
+  <p>
+    Access to the site is free and open. By browsing it you accept the terms described
+    in this notice and in the complementary policies (<a href="/en/privacy">Privacy</a>
+    and <a href="/en/cookies">Cookies</a>).
+  </p>
+  <p>
+    You agree to use the site lawfully, without harming its operation or the rights of
+    the owner or third parties. Sending illegal, offensive or malicious content via the
+    contact form is forbidden.
+  </p>
+
+  <h2>3. Intellectual property</h2>
+  <p>
+    Original content of the blog (text, own images, design and site source code) belongs
+    to Aitor Reviriego Amor unless stated otherwise. Reading and citing with attribution
+    and a link back are allowed.
+  </p>
+  <p>
+    Substantial reproductions, translations or commercial use require prior written
+    authorisation. Code snippets published on the blog are provided as examples and may
+    be freely reused unless a different licence is specified in the post or repository.
+  </p>
+
+  <h2>4. Third-party links</h2>
+  <p>
+    The site may link to external pages. No liability is assumed for their content,
+    availability or privacy policies. A link does not imply recommendation or commercial
+    relationship unless explicitly stated.
+  </p>
+
+  <h2>5. Disclaimer of warranties and liability</h2>
+  <p>
+    The site is provided "as is" with the reasonable diligence expected from a personal
+    blog. No guarantee is given of the absence of errors, temporary outages or
+    inaccuracies. The owner is exempt from liability for damages arising from use of
+    the site provided such diligence has been observed.
+  </p>
+
+  <h2>6. Changes</h2>
+  <p>
+    The owner may update this legal notice at any time. The "last updated" date is shown
+    at the top. Substantial changes will be announced on the site.
+  </p>
+
+  <h2>7. Applicable law and jurisdiction</h2>
+  <p>
+    This notice is governed by Spanish law. Any dispute arising from the use of the site
+    will be subject to the courts and tribunals competent under the applicable regulations.
+  </p>
+</LegalPageLayout>

--- a/src/pages/en/privacy.astro
+++ b/src/pages/en/privacy.astro
@@ -1,0 +1,105 @@
+---
+import LegalPageLayout from '../../components/legal/LegalPageLayout.astro';
+---
+
+<LegalPageLayout
+  lang="en"
+  title="Privacy Policy"
+  description="Privacy policy for aitorevi.dev: what personal data we process, processors involved, legal basis, and how to exercise your rights."
+  updatedDate="2026-04-22"
+>
+  <p>
+    This page explains what personal data is processed through
+    <a href="https://www.aitorevi.dev">aitorevi.dev</a>, the purposes, the processors
+    involved, and how you can exercise the rights granted by the General Data Protection
+    Regulation (GDPR) and the Spanish Organic Law 3/2018 (LOPDGDD).
+  </p>
+
+  <h2>1. Data controller</h2>
+  <ul>
+    <li><strong>Owner:</strong> Aitor Reviriego Amor.</li>
+    <li><strong>Contact email:</strong> <a href="mailto:info@aitorevi.dev">info@aitorevi.dev</a>.</li>
+    <li><strong>Activity:</strong> personal blog about software development.</li>
+  </ul>
+
+  <h2>2. Data processed and purpose</h2>
+  <h3>2.1 Contact form</h3>
+  <p>
+    When you submit the form, the following data is processed: <strong>name, email and
+    message content</strong>. The purpose is to reply to your enquiry. Data is deleted
+    when the conversation is no longer relevant, or whenever you explicitly request it.
+  </p>
+
+  <h3>2.2 Browsing and analytics</h3>
+  <p>
+    When you access the site, technical data such as IP address, browser type, pages
+    visited and referrer is collected. Part of it is stored (anonymised) in Google
+    Analytics 4 for statistical purposes. Analytics <strong>is only activated if you
+    consent to analytics cookies</strong> via the banner shown on your first visit.
+  </p>
+
+  <h3>2.3 Abuse prevention (rate limiting)</h3>
+  <p>
+    The contact form applies a submission limit per IP to prevent spam and automated
+    abuse. A hash of your IP is stored temporarily in Upstash Redis for up to 1 hour.
+  </p>
+
+  <h2>3. Legal basis</h2>
+  <ul>
+    <li><strong>Contact form</strong>: your consent when submitting the message (GDPR art. 6.1.a).</li>
+    <li><strong>Analytics</strong>: consent via the cookie banner (GDPR art. 6.1.a and LSSI-CE art. 22).</li>
+    <li><strong>Rate limiting</strong>: legitimate interest in preventing abuse (GDPR art. 6.1.f).</li>
+  </ul>
+
+  <h2>4. Processors and recipients</h2>
+  <p>The service relies on the following providers:</p>
+  <ul>
+    <li><strong>Vercel Inc.</strong> — hosting and performance analytics (Web Vitals). US-based; international transfer covered by Standard Contractual Clauses approved by the European Commission.</li>
+    <li><strong>Google LLC</strong> — Google Analytics 4 (only with consent) and Google Search Console (aggregated indexing data only, no personal data). US-based, SCCs.</li>
+    <li><strong>Resend, Inc.</strong> — transactional email sending (contact form confirmation). US-based, SCCs.</li>
+    <li><strong>Upstash Inc.</strong> — ephemeral storage of IP hashes for rate limiting. US-based, SCCs.</li>
+    <li><strong>GitHub, Inc.</strong> — source code and editable content storage (via Keystatic). US-based, SCCs.</li>
+  </ul>
+  <p>
+    No data is shared with third parties outside these processors except where legally
+    required. No automated decision-making or profiling is performed.
+  </p>
+
+  <h2>5. Retention periods</h2>
+  <ul>
+    <li><strong>Contact form messages</strong>: until they are no longer needed or you request deletion.</li>
+    <li><strong>Analytics cookies</strong>: see the cookies policy (<a href="/en/cookies">/en/cookies</a>). Maximum 2 years.</li>
+    <li><strong>Rate limiting</strong>: maximum 1 hour.</li>
+  </ul>
+
+  <h2>6. Your rights</h2>
+  <p>As data subject you may exercise the following rights at any time:</p>
+  <ul>
+    <li>Access to your data.</li>
+    <li>Rectification of inaccurate data.</li>
+    <li>Erasure ("right to be forgotten").</li>
+    <li>Restriction of processing.</li>
+    <li>Objection to processing.</li>
+    <li>Data portability.</li>
+    <li>Withdrawal of consent.</li>
+  </ul>
+  <p>
+    To exercise them, write to <a href="mailto:info@aitorevi.dev">info@aitorevi.dev</a>
+    stating which right you wish to exercise. If you consider your request has not been
+    properly handled, you may lodge a complaint with the Spanish Data Protection Agency
+    (<a href="https://www.aepd.es" target="_blank" rel="noopener noreferrer">aepd.es</a>).
+  </p>
+
+  <h2>7. Security</h2>
+  <p>
+    Reasonable technical and organisational measures are applied to protect your data:
+    TLS-encrypted connections, providers with up-to-date GDPR policies, limited data
+    access, and data-minimisation principles.
+  </p>
+
+  <h2>8. Changes to this policy</h2>
+  <p>
+    This policy may be updated to reflect legal or technical changes. The "last updated"
+    date is shown at the top. Substantial changes will be announced on the site in advance.
+  </p>
+</LegalPageLayout>

--- a/src/pages/privacidad.astro
+++ b/src/pages/privacidad.astro
@@ -1,0 +1,108 @@
+---
+import LegalPageLayout from '../components/legal/LegalPageLayout.astro';
+---
+
+<LegalPageLayout
+  lang="es"
+  title="Política de Privacidad"
+  description="Política de privacidad de aitorevi.dev: datos que tratamos, encargados, base legal y cómo ejercer tus derechos."
+  updatedDate="2026-04-22"
+>
+  <p>
+    En esta página se explica qué datos personales se tratan a través de
+    <a href="https://www.aitorevi.dev">aitorevi.dev</a>, con qué finalidad, qué encargados
+    intervienen y cómo puedes ejercer los derechos que te reconoce el Reglamento General
+    de Protección de Datos (RGPD) y la Ley Orgánica 3/2018 (LOPDGDD).
+  </p>
+
+  <h2>1. Responsable del tratamiento</h2>
+  <ul>
+    <li><strong>Titular:</strong> Aitor Reviriego Amor.</li>
+    <li><strong>Email de contacto:</strong> <a href="mailto:info@aitorevi.dev">info@aitorevi.dev</a>.</li>
+    <li><strong>Actividad:</strong> blog personal sobre desarrollo de software.</li>
+  </ul>
+
+  <h2>2. Datos que se tratan y finalidad</h2>
+  <h3>2.1 Formulario de contacto</h3>
+  <p>
+    Cuando envías un mensaje a través del formulario se tratan los siguientes datos:
+    <strong>nombre, email y contenido del mensaje</strong>. La finalidad es responderte
+    a lo que plantees. Los datos se eliminan cuando la conversación deja de ser relevante
+    o cuando lo solicitas expresamente.
+  </p>
+
+  <h3>2.2 Navegación y analítica</h3>
+  <p>
+    Cuando accedes al sitio se recogen datos técnicos como dirección IP, tipo de navegador,
+    páginas visitadas y referrer. Una parte se almacena anonimizada en Google Analytics 4
+    con fines estadísticos. La analítica <strong>solo se activa si has consentido las cookies
+    analíticas</strong> en el banner que ves en tu primera visita.
+  </p>
+
+  <h3>2.3 Limitación de abuso (rate limiting)</h3>
+  <p>
+    El formulario de contacto aplica un límite de envíos por IP para evitar spam y abuso
+    automatizado. Para ello se almacena temporalmente un hash de tu IP en Upstash Redis
+    durante como máximo 1 hora.
+  </p>
+
+  <h2>3. Base legal</h2>
+  <ul>
+    <li><strong>Formulario de contacto</strong>: consentimiento al enviar el mensaje (art. 6.1.a RGPD).</li>
+    <li><strong>Analítica</strong>: consentimiento mediante banner de cookies (art. 6.1.a RGPD y art. 22 LSSI-CE).</li>
+    <li><strong>Rate limiting</strong>: interés legítimo en prevenir usos abusivos (art. 6.1.f RGPD).</li>
+  </ul>
+
+  <h2>4. Encargados y cesionarios</h2>
+  <p>Para ofrecer el servicio se apoya en los siguientes proveedores:</p>
+  <ul>
+    <li><strong>Vercel Inc.</strong> — hosting y analítica de rendimiento (Web Vitals). EE. UU., transferencia internacional cubierta por Cláusulas Contractuales Tipo aprobadas por la Comisión Europea.</li>
+    <li><strong>Google LLC</strong> — Google Analytics 4 (solo con consent) y Google Search Console (solo datos agregados de indexación, no personales). EE. UU., CCT.</li>
+    <li><strong>Resend, Inc.</strong> — envío transaccional del email de confirmación del formulario de contacto. EE. UU., CCT.</li>
+    <li><strong>Upstash Inc.</strong> — almacenamiento efímero de hashes de IP para rate limiting. EE. UU., CCT.</li>
+    <li><strong>GitHub, Inc.</strong> — almacenamiento del código fuente y, a través de Keystatic, del contenido editable. EE. UU., CCT.</li>
+  </ul>
+  <p>
+    No se ceden datos a terceros fuera de estos encargados salvo obligación legal. No se
+    realiza toma de decisiones automatizada ni elaboración de perfiles.
+  </p>
+
+  <h2>5. Plazos de conservación</h2>
+  <ul>
+    <li><strong>Mensajes del formulario</strong>: hasta que dejen de ser necesarios o lo solicites.</li>
+    <li><strong>Cookies analíticas</strong>: según la política de cookies (ver <a href="/cookies">/cookies</a>). Máximo 2 años.</li>
+    <li><strong>Rate limiting</strong>: máximo 1 hora.</li>
+  </ul>
+
+  <h2>6. Tus derechos</h2>
+  <p>Como titular de los datos puedes ejercer en cualquier momento los siguientes derechos:</p>
+  <ul>
+    <li>Acceso a tus datos.</li>
+    <li>Rectificación de datos inexactos.</li>
+    <li>Supresión ("derecho al olvido").</li>
+    <li>Limitación del tratamiento.</li>
+    <li>Oposición al tratamiento.</li>
+    <li>Portabilidad de los datos.</li>
+    <li>Retirar el consentimiento prestado.</li>
+  </ul>
+  <p>
+    Para ejercerlos escribe a <a href="mailto:info@aitorevi.dev">info@aitorevi.dev</a>
+    indicando el derecho que quieres ejercer. Si consideras que no se ha atendido
+    adecuadamente, puedes reclamar ante la Agencia Española de Protección de Datos
+    (<a href="https://www.aepd.es" target="_blank" rel="noopener noreferrer">aepd.es</a>).
+  </p>
+
+  <h2>7. Seguridad</h2>
+  <p>
+    Se aplican medidas técnicas y organizativas razonables para proteger los datos:
+    conexiones cifradas con TLS, uso de proveedores con políticas RGPD actualizadas,
+    acceso limitado a los datos y principio de minimización.
+  </p>
+
+  <h2>8. Cambios en esta política</h2>
+  <p>
+    Esta política puede actualizarse para reflejar cambios legales o técnicos. La fecha
+    de última actualización aparece arriba. Los cambios sustanciales se comunicarán en el
+    sitio con antelación.
+  </p>
+</LegalPageLayout>


### PR DESCRIPTION
## Summary

Añade las tres páginas legales bilingües como base RGPD/LSSI-CE del blog, siguiendo el patrón de colorprof.es (tres páginas separadas y concisas):

- `/privacidad` · `/en/privacy` — Política de Privacidad (datos tratados, encargados, base legal, derechos ARCO-POL, contacto AEPD).
- `/cookies` · `/en/cookies` — Política de Cookies con **tabla de cookies reales** usadas (`aitorevi_consent`, `_ga`, `_ga_<id>`).
- `/aviso-legal` · `/en/legal-notice` — Aviso Legal LSSI-CE art. 10.

## Detalles técnicos

- Nuevo componente `src/components/legal/LegalPageLayout.astro` que centraliza el shell (Layout \`dark-radial\` + prose + header con \"última actualización\").
- Cada ruta es un `.astro` independiente con contenido inline — suficiente para 3 páginas, no justifica una content collection.
- Footer actualizado: enlaces \"Privacidad · Cookies · Aviso Legal\" (ES) / \"Privacy · Cookies · Legal Notice\" (EN) junto al copyright.
- Enlaces cruzados entre las tres (Privacidad → Cookies → Privacidad, etc.) y al email de contacto.

## RGPD coverage

- **Responsable**: Aitor Reviriego Amor.
- **Encargados declarados**: Vercel, Google (GA4 + GSC), Resend, Upstash, GitHub.
- **Bases legales**: consentimiento (formulario + analítica), interés legítimo (rate limiting).
- **Transferencias internacionales**: EE. UU. vía CCT aprobadas por la Comisión Europea.
- **Derechos**: acceso, rectificación, supresión, limitación, oposición, portabilidad, retirada de consentimiento.

## Lo que **no** hace este PR

- Banner de cookies — queda en #59 (a partir de esta base).
- Consent Mode v2 activo — seguirá con default \`granted\` hasta que #59 lo cambie.

## Test plan
- [x] \`npm run build\` → todas las rutas renderizan en el build estático.
- [x] \`npm test\` → 127/127 tests verdes.
- [ ] Revisar visualmente en dev: \`/privacidad\`, \`/cookies\`, \`/aviso-legal\` + sus versiones EN. Que el Layout, dark mode, tipografía sean coherentes.
- [ ] Confirmar que los enlaces del footer navegan a las páginas correctas en ES y EN.
- [ ] Validar que los textos legales se ajustan a tu realidad (email, actividad, licencias). Eres responsable final del contenido.

Closes #60
Related: #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)