### PR TITLE
feat(consent): cookie banner + Consent Mode v2

### DIFF
--- a/src/components/Footer/Footer.astro
+++ b/src/components/Footer/Footer.astro
@@ -17,6 +17,8 @@ const legalLinks = isES
         { label: 'Cookies', href: '/en/cookies' },
         { label: 'Legal Notice', href: '/en/legal-notice' },
       ];
+
+const manageCookiesLabel = isES ? 'Gestionar cookies' : 'Manage cookies';
 ---
 <footer class="relative flex flex-col w-full items-center justify-center gap-2 py-5 md:py-6 bg-white/90 dark:bg-ink-800/60 backdrop-blur-md border-t border-gray-200 dark:border-white/10 transition-colors duration-200">
     <div class="flex items-center justify-center gap-8">
@@ -42,5 +44,19 @@ const legalLinks = isES
                 </a>
             </>
         ))}
+        <span aria-hidden="true">·</span>
+        <button type="button" id="manage-cookies" class="hover:text-secondary dark:hover:text-accent-blue transition-colors duration-200 uppercase tracking-[0.2em]">
+            {manageCookiesLabel}
+        </button>
     </nav>
 </footer>
+
+<script is:inline>
+    document.addEventListener('astro:page-load', function () {
+        var btn = document.getElementById('manage-cookies');
+        if (!btn) return;
+        btn.addEventListener('click', function () {
+            document.dispatchEvent(new CustomEvent('aitorevi:reopen-consent'));
+        });
+    });
+</script>

--- a/src/components/analytics/CookieConsent.astro
+++ b/src/components/analytics/CookieConsent.astro
@@ -1,0 +1,131 @@
+---
+import { getLangFromUrl } from '../../i18n/utils';
+
+const lang = getLangFromUrl(Astro.url);
+const isES = lang === 'es';
+
+const copy = isES
+  ? {
+      message:
+        'Uso cookies propias para recordar tu preferencia de consentimiento y, solo si aceptas, cookies de Google Analytics para entender el uso del sitio de forma agregada.',
+      moreInfoLabel: 'Política de Cookies',
+      moreInfoHref: '/cookies',
+      privacyLabel: 'Privacidad',
+      privacyHref: '/privacidad',
+      accept: 'Aceptar',
+      reject: 'Rechazar',
+      ariaLabel: 'Aviso de cookies',
+    }
+  : {
+      message:
+        'I use a first-party cookie to remember your consent choice and, only if you accept, Google Analytics cookies to understand aggregate site usage.',
+      moreInfoLabel: 'Cookie Policy',
+      moreInfoHref: '/en/cookies',
+      privacyLabel: 'Privacy',
+      privacyHref: '/en/privacy',
+      accept: 'Accept',
+      reject: 'Reject',
+      ariaLabel: 'Cookie notice',
+    };
+---
+
+<div
+  id="cookie-consent"
+  role="dialog"
+  aria-live="polite"
+  aria-label={copy.ariaLabel}
+  hidden
+  class="fixed inset-x-0 bottom-0 z-50 border-t border-slate-200 bg-white/95 backdrop-blur-md shadow-[0_-10px_40px_-15px_rgba(15,23,42,0.2)] dark:border-white/10 dark:bg-ink-900/95"
+>
+  <div class="mx-auto flex max-w-5xl flex-col gap-4 px-6 py-4 md:flex-row md:items-center md:justify-between">
+    <p class="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+      {copy.message}
+      <br class="hidden md:block" />
+      <span class="font-mono text-[11px] uppercase tracking-[0.15em]">
+        <a href={copy.moreInfoHref} class="text-secondary hover:text-accent-violet dark:text-accent-blue dark:hover:text-accent-violet underline-offset-2 hover:underline">
+          {copy.moreInfoLabel}
+        </a>
+        <span aria-hidden="true" class="mx-2 text-slate-400">·</span>
+        <a href={copy.privacyHref} class="text-secondary hover:text-accent-violet dark:text-accent-blue dark:hover:text-accent-violet underline-offset-2 hover:underline">
+          {copy.privacyLabel}
+        </a>
+      </span>
+    </p>
+    <div class="flex shrink-0 items-center gap-2">
+      <button
+        type="button"
+        data-cookie-reject
+        class="rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:border-slate-500 hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary dark:border-white/20 dark:text-slate-200 dark:hover:bg-white/5"
+      >
+        {copy.reject}
+      </button>
+      <button
+        type="button"
+        data-cookie-accept
+        class="rounded-full bg-secondary px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors hover:bg-accent-violet focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 dark:bg-accent-violet dark:hover:bg-accent-blue"
+      >
+        {copy.accept}
+      </button>
+    </div>
+  </div>
+</div>
+
+<script is:inline>
+  (function () {
+    var COOKIE_NAME = 'aitorevi_consent';
+    var MAX_AGE = 60 * 60 * 24 * 365; // 1 year
+
+    function readConsent() {
+      var m = document.cookie.match(/(?:^|; )aitorevi_consent=(granted|denied)/);
+      return m ? m[1] : null;
+    }
+
+    function writeConsent(value) {
+      var secure = location.protocol === 'https:' ? '; Secure' : '';
+      document.cookie =
+        COOKIE_NAME + '=' + value + '; max-age=' + MAX_AGE + '; path=/; SameSite=Lax' + secure;
+    }
+
+    function updateGtag(value) {
+      if (typeof window.gtag !== 'function') return;
+      window.gtag('consent', 'update', {
+        analytics_storage: value === 'granted' ? 'granted' : 'denied',
+      });
+    }
+
+    function init() {
+      var banner = document.getElementById('cookie-consent');
+      if (!banner) return;
+
+      var current = readConsent();
+      if (!current) {
+        banner.hidden = false;
+      }
+
+      banner.querySelectorAll('[data-cookie-accept]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          writeConsent('granted');
+          updateGtag('granted');
+          banner.hidden = true;
+        });
+      });
+
+      banner.querySelectorAll('[data-cookie-reject]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          writeConsent('denied');
+          updateGtag('denied');
+          banner.hidden = true;
+        });
+      });
+    }
+
+    // Re-init after each view transition (fresh DOM references).
+    document.addEventListener('astro:page-load', init);
+
+    // External trigger to reopen the banner (footer "Manage cookies" link).
+    document.addEventListener('aitorevi:reopen-consent', function () {
+      var banner = document.getElementById('cookie-consent');
+      if (banner) banner.hidden = false;
+    });
+  })();
+</script>

--- a/src/components/analytics/GoogleAnalytics.astro
+++ b/src/components/analytics/GoogleAnalytics.astro
@@ -13,11 +13,16 @@ const shouldLoad = Boolean(id) && !isExcluded;
       window.gtag = gtag;
 
       gtag('consent', 'default', {
-        analytics_storage: 'granted',
+        analytics_storage: 'denied',
         ad_storage: 'denied',
         ad_user_data: 'denied',
         ad_personalization: 'denied',
       });
+
+      var storedConsent = (document.cookie.match(/(?:^|; )aitorevi_consent=(granted|denied)/) || [])[1];
+      if (storedConsent === 'granted') {
+        gtag('consent', 'update', { analytics_storage: 'granted' });
+      }
 
       gtag('js', new Date());
       gtag('config', id, { send_page_view: false, anonymize_ip: true });

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import { ClientRouter } from 'astro:transitions';
 import Analytics from '@vercel/analytics/astro';
 import GoogleAnalytics from '../components/analytics/GoogleAnalytics.astro';
+import CookieConsent from '../components/analytics/CookieConsent.astro';
 import Nav from "../components/Nav/Nav.astro";
 import Footer from "../components/Footer/Footer.astro";
 import { getLangFromUrl, getAlternateUrl, t } from '../i18n/utils';
@@ -99,6 +100,7 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `https://www.aitorevi.
 		</main>
 		<Footer />
 		<Analytics />
+		<CookieConsent />
 	</body>
 </html>
 <style is:global>


### PR DESCRIPTION
## Summary

Añade el banner de cookies y conecta Google Consent Mode v2. Patrón colorprof.es: barra inferior con dos botones (*Aceptar* / *Rechazar*), sin opción granular.

- Componente `src/components/analytics/CookieConsent.astro` — barra inferior con dos botones, bilingüe, con enlaces a Cookies + Privacidad.
- Cookie propia `aitorevi_consent` (1 año, `SameSite=Lax`, `Secure` en HTTPS).
- `GoogleAnalytics.astro`: default `analytics_storage: denied`. Lee la cookie antes del `gtag('config')` para actualizar consent inmediatamente si ya había aceptación previa (evita perder el primer `page_view` de la sesión).
- Footer: botón \"Gestionar cookies\" / \"Manage cookies\" que dispara `CustomEvent('aitorevi:reopen-consent')`.
- Compatible con view transitions: `astro:page-load` re-inicializa el banner contra el DOM nuevo sin duplicar listeners.

## Criterios de aceptación (del issue)

- [ ] Primera visita: banner visible, GA no dispara hits (Network → `collect` no aparece).
- [ ] Tras \"Aceptar\": cookie `aitorevi_consent=granted`, banner oculto, GA dispara `page_view`.
- [ ] Tras \"Rechazar\": cookie `aitorevi_consent=denied`, banner oculto, GA no dispara hits.
- [ ] \"Gestionar cookies\" del footer reabre el banner.
- [ ] Elección persiste entre visitas (mientras la cookie viva).

## Test plan
- [x] `npm run build` verde.
- [x] `npm test` — 127/127 verdes.
- [ ] Dev local → abrir home en ventana nueva: banner aparece al pie, legible en dark/light.
- [ ] Clicar \"Aceptar\" → recargar → banner ya no aparece, GA dispara hits.
- [ ] Clicar \"Gestionar cookies\" del footer → banner reaparece.
- [ ] Clicar \"Rechazar\" → recargar → banner oculto, GA no manda hits.
- [ ] Navegar entre rutas (view transitions): el banner no se duplica ni reaparece.

## Lo que **no** hace este PR
- No toca las páginas legales (ya en #62).
- No añade consent granular (categorías).

Closes #59
Related: #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)