### PR TITLE
style(contact): bajar el volumen visual de la cláusula RGPD

### DIFF
--- a/src/components/home/ContactSection.astro
+++ b/src/components/home/ContactSection.astro
@@ -150,19 +150,18 @@ const { lang } = Astro.props;
       </label>
 
       <!-- RGPD — cláusula informativa básica -->
-      <div class="mt-8 rounded-xl border border-slate-200 bg-slate-50/80 p-4 text-[13px] leading-relaxed text-slate-700 dark:border-white/10 dark:bg-white/[0.03] dark:text-slate-300">
-        <p class="mb-2 flex items-center gap-2 font-semibold text-ink-900 dark:text-slate-100">
-          <span aria-hidden="true">🔒</span>
+      <section class="mt-6 border-t border-slate-200/70 pt-4 dark:border-white/5" aria-labelledby="contact-privacy-heading">
+        <p id="contact-privacy-heading" class="mb-2 font-mono text-[10px] uppercase tracking-[0.2em] text-secondary/70 dark:text-accent-blue/50">
           {t(lang, 'home.contact.privacy.heading')}
         </p>
-        <ul class="space-y-1 list-none p-0">
-          <li><strong>{t(lang, 'home.contact.privacy.responsable')}</strong> {t(lang, 'home.contact.privacy.responsableValue')}</li>
-          <li><strong>{t(lang, 'home.contact.privacy.finalidad')}</strong> {t(lang, 'home.contact.privacy.finalidadValue')}</li>
-          <li><strong>{t(lang, 'home.contact.privacy.legitimacion')}</strong> {t(lang, 'home.contact.privacy.legitimacionValue')}</li>
-          <li><strong>{t(lang, 'home.contact.privacy.destinatarios')}</strong> {t(lang, 'home.contact.privacy.destinatariosValue')}</li>
-          <li><strong>{t(lang, 'home.contact.privacy.derechos')}</strong> {t(lang, 'home.contact.privacy.derechosValue')}</li>
+        <ul class="space-y-0.5 list-none p-0 text-[11px] leading-relaxed text-slate-500 dark:text-slate-500">
+          <li><span class="text-slate-600 dark:text-slate-400">{t(lang, 'home.contact.privacy.responsable')}</span> {t(lang, 'home.contact.privacy.responsableValue')}</li>
+          <li><span class="text-slate-600 dark:text-slate-400">{t(lang, 'home.contact.privacy.finalidad')}</span> {t(lang, 'home.contact.privacy.finalidadValue')}</li>
+          <li><span class="text-slate-600 dark:text-slate-400">{t(lang, 'home.contact.privacy.legitimacion')}</span> {t(lang, 'home.contact.privacy.legitimacionValue')}</li>
+          <li><span class="text-slate-600 dark:text-slate-400">{t(lang, 'home.contact.privacy.destinatarios')}</span> {t(lang, 'home.contact.privacy.destinatariosValue')}</li>
+          <li><span class="text-slate-600 dark:text-slate-400">{t(lang, 'home.contact.privacy.derechos')}</span> {t(lang, 'home.contact.privacy.derechosValue')}</li>
         </ul>
-      </div>
+      </section>
 
       <!-- Consent checkbox — required -->
       <label class="mt-5 flex items-start gap-2.5 text-sm text-slate-700 dark:text-slate-300" for="contact-consent">

--- a/src/components/home/ContactSection.astro
+++ b/src/components/home/ContactSection.astro
@@ -154,17 +154,17 @@ const { lang } = Astro.props;
         <p id="contact-privacy-heading" class="mb-2 font-mono text-[10px] uppercase tracking-[0.2em] text-secondary/70 dark:text-accent-blue/50">
           {t(lang, 'home.contact.privacy.heading')}
         </p>
-        <ul class="space-y-0.5 list-none p-0 text-[11px] leading-relaxed text-slate-500 dark:text-slate-500">
-          <li><span class="text-slate-600 dark:text-slate-400">{t(lang, 'home.contact.privacy.responsable')}</span> {t(lang, 'home.contact.privacy.responsableValue')}</li>
-          <li><span class="text-slate-600 dark:text-slate-400">{t(lang, 'home.contact.privacy.finalidad')}</span> {t(lang, 'home.contact.privacy.finalidadValue')}</li>
-          <li><span class="text-slate-600 dark:text-slate-400">{t(lang, 'home.contact.privacy.legitimacion')}</span> {t(lang, 'home.contact.privacy.legitimacionValue')}</li>
-          <li><span class="text-slate-600 dark:text-slate-400">{t(lang, 'home.contact.privacy.destinatarios')}</span> {t(lang, 'home.contact.privacy.destinatariosValue')}</li>
-          <li><span class="text-slate-600 dark:text-slate-400">{t(lang, 'home.contact.privacy.derechos')}</span> {t(lang, 'home.contact.privacy.derechosValue')}</li>
-        </ul>
+        <p class="text-[11px] leading-relaxed text-slate-500 dark:text-slate-500">
+          <span class="text-slate-600 dark:text-slate-400">{t(lang, 'home.contact.privacy.responsable')}</span> {t(lang, 'home.contact.privacy.responsableValue')}{' '}
+          <span class="text-slate-600 dark:text-slate-400">{t(lang, 'home.contact.privacy.finalidad')}</span> {t(lang, 'home.contact.privacy.finalidadValue')}{' '}
+          <span class="text-slate-600 dark:text-slate-400">{t(lang, 'home.contact.privacy.legitimacion')}</span> {t(lang, 'home.contact.privacy.legitimacionValue')}{' '}
+          <span class="text-slate-600 dark:text-slate-400">{t(lang, 'home.contact.privacy.destinatarios')}</span> {t(lang, 'home.contact.privacy.destinatariosValue')}{' '}
+          <span class="text-slate-600 dark:text-slate-400">{t(lang, 'home.contact.privacy.derechos')}</span> {t(lang, 'home.contact.privacy.derechosValue')}
+        </p>
       </section>
 
       <!-- Consent checkbox — required -->
-      <label class="mt-5 flex items-start gap-2.5 text-sm text-slate-700 dark:text-slate-300" for="contact-consent">
+      <label class="mt-4 flex items-start gap-2 text-[11px] leading-relaxed text-slate-500 dark:text-slate-500" for="contact-consent">
         <input
           id="contact-consent"
           type="checkbox"
@@ -172,21 +172,21 @@ const { lang } = Astro.props;
           required
           data-field="consent"
           aria-describedby="contact-consent-error"
-          class="mt-0.5 h-4 w-4 flex-shrink-0 rounded border border-slate-300 text-secondary accent-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/60 focus-visible:ring-offset-1 dark:border-white/20 dark:accent-accent-violet"
+          class="mt-0.5 h-3.5 w-3.5 flex-shrink-0 rounded border border-slate-300 text-secondary accent-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/60 focus-visible:ring-offset-1 dark:border-white/20 dark:accent-accent-violet"
         />
         <span>
           {t(lang, 'home.contact.consent.label')}
           {' '}
-          <a href={lang === 'es' ? '/privacidad' : '/en/privacy'} class="text-secondary hover:text-accent-violet dark:text-accent-blue dark:hover:text-accent-violet underline-offset-2 hover:underline">
+          <a href={lang === 'es' ? '/privacidad' : '/en/privacy'} class="text-secondary/80 hover:text-accent-violet dark:text-accent-blue/70 dark:hover:text-accent-violet underline-offset-2 hover:underline">
             {t(lang, 'home.contact.consent.linkLabel')}
           </a>
           <span aria-hidden="true"> *</span>
-          <span class="ml-1 text-rose-500 dark:text-rose-400 font-medium">
+          <span class="ml-1 text-slate-500/70 dark:text-slate-500/70">
             {t(lang, 'home.contact.consent.required')}
           </span>
         </span>
       </label>
-      <span id="contact-consent-error" data-field-error="consent" class="mt-1 ml-7 hidden text-[11px] text-rose-400 font-mono" aria-live="polite"></span>
+      <span id="contact-consent-error" data-field-error="consent" class="mt-1 ml-6 hidden text-[11px] text-rose-400 font-mono" aria-live="polite"></span>
 
       <div class="mt-6 flex justify-end">
         <Button type="submit" variant="gradient" tone="brand">


### PR DESCRIPTION
## Summary

La cláusula de protección de datos y el label del checkbox se comían demasiado foco comparado con el resto del formulario. Ajustes pedidos por el usuario:

- **Estilos alineados con el resto del form**: el heading usa el mismo patrón mono/uppercase/tracking que los labels de los campos (\`text-[10px] tracking-[0.2em] text-secondary/70\`).
- **Sin emoji** 🔒.
- **Sin tarjeta ni fondo propio** — solo un \`border-t\` sutil como separador.
- **Texto más pequeño y muted** (\`text-[11px] text-slate-500\`), etiquetas (Responsable, Finalidad, …) en \`text-slate-600\` sin bold.
- **Todo en un único párrafo**, sin saltos de línea entre los cinco puntos.
- **Checkbox de consent**: también \`text-[11px] text-slate-500\`, \"(Obligatorio)\" deja de ir en rojo saturado y pasa a slate muted — el asterisco y el atributo \`required\` ya marcan la obligatoriedad.

## Test plan
- [x] \`npm run build\` verde.
- [ ] Ver en dev: sección se integra con el resto del formulario sin destacar.
- [ ] Mobile: el párrafo fluye sin romper layout.
- [ ] Dark mode: el contraste sigue siendo legible (slate-500 sobre fondo oscuro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)