### PR TITLE
style(privacy): quitar enlace auto-referencial en la intro

### DIFF
--- a/src/pages/en/privacy.astro
+++ b/src/pages/en/privacy.astro
@@ -9,10 +9,9 @@ import LegalPageLayout from '../../components/legal/LegalPageLayout.astro';
   updatedDate="2026-04-22"
 >
   <p>
-    This page explains what personal data is processed through
-    <a href="https://www.aitorevi.dev">aitorevi.dev</a>, the purposes, the processors
-    involved, and how you can exercise the rights granted by the General Data Protection
-    Regulation (GDPR) and the Spanish Organic Law 3/2018 (LOPDGDD).
+    This page explains what personal data is processed through aitorevi.dev, the purposes,
+    the processors involved, and how you can exercise the rights granted by the General
+    Data Protection Regulation (GDPR) and the Spanish Organic Law 3/2018 (LOPDGDD).
   </p>
 
   <h2>1. Data controller</h2>

--- a/src/pages/privacidad.astro
+++ b/src/pages/privacidad.astro
@@ -9,10 +9,10 @@ import LegalPageLayout from '../components/legal/LegalPageLayout.astro';
   updatedDate="2026-04-22"
 >
   <p>
-    En esta página se explica qué datos personales se tratan a través de
-    <a href="https://www.aitorevi.dev">aitorevi.dev</a>, con qué finalidad, qué encargados
-    intervienen y cómo puedes ejercer los derechos que te reconoce el Reglamento General
-    de Protección de Datos (RGPD) y la Ley Orgánica 3/2018 (LOPDGDD).
+    En esta página se explica qué datos personales se tratan a través de aitorevi.dev,
+    con qué finalidad, qué encargados intervienen y cómo puedes ejercer los derechos que
+    te reconoce el Reglamento General de Protección de Datos (RGPD) y la Ley Orgánica
+    3/2018 (LOPDGDD).
   </p>
 
   <h2>1. Responsable del tratamiento</h2>


### PR DESCRIPTION
## Summary

El enlace \"aitorevi.dev\" en la intro de la página de Privacidad (y su gemela en inglés) apuntaba al propio site donde ya estás, no aportaba navegación y solo añadía ruido visual. Ahora va en texto plano.

## Test plan
- [ ] Abrir /privacidad y /en/privacy tras el deploy: el primer párrafo menciona aitorevi.dev como texto, no como link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)