### PR TITLE
fix(i18n): selector de idioma en páginas legales con slug traducido

### DIFF
--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -9,7 +9,21 @@ export function getLangFromUrl(url: URL): Lang {
   return url.pathname.startsWith('/en') ? 'en' : 'es';
 }
 
+// Pages whose slug is translated (not a mechanical /en prefix swap).
+// Keys are the full path as served; values are the alternate-language
+// counterpart. Both directions must be declared so the lookup is symmetric.
+const TRANSLATED_SLUG_MAP: Record<string, string> = {
+  '/privacidad': '/en/privacy',
+  '/en/privacy': '/privacidad',
+  '/aviso-legal': '/en/legal-notice',
+  '/en/legal-notice': '/aviso-legal',
+};
+
 export function getAlternateUrl(currentPath: string, currentLang: Lang): string {
+  const normalised = currentPath.replace(/\/$/, '') || '/';
+  const mapped = TRANSLATED_SLUG_MAP[normalised];
+  if (mapped) return mapped;
+
   const isBlogPost = /^(\/en)?\/blog\/.+/.test(currentPath);
   if (isBlogPost) {
     const slug = currentPath.replace(/^\/en/, '').replace(/^\/blog\//, '');

--- a/tests/unit/i18n/utils.test.ts
+++ b/tests/unit/i18n/utils.test.ts
@@ -68,6 +68,34 @@ describe('getAlternateUrl', () => {
   it('switches EN → ES for /en/cv', () => {
     expect(getAlternateUrl('/en/cv', 'en')).toBe('/cv');
   });
+
+  // Legal pages — some have translated slugs and need explicit mapping,
+  // others share the slug across languages.
+  it('maps /privacidad → /en/privacy (translated slug)', () => {
+    expect(getAlternateUrl('/privacidad', 'es')).toBe('/en/privacy');
+  });
+
+  it('maps /en/privacy → /privacidad (translated slug)', () => {
+    expect(getAlternateUrl('/en/privacy', 'en')).toBe('/privacidad');
+  });
+
+  it('maps /aviso-legal → /en/legal-notice (translated slug)', () => {
+    expect(getAlternateUrl('/aviso-legal', 'es')).toBe('/en/legal-notice');
+  });
+
+  it('maps /en/legal-notice → /aviso-legal (translated slug)', () => {
+    expect(getAlternateUrl('/en/legal-notice', 'en')).toBe('/aviso-legal');
+  });
+
+  it('keeps /cookies shared slug working in both directions', () => {
+    expect(getAlternateUrl('/cookies', 'es')).toBe('/en/cookies');
+    expect(getAlternateUrl('/en/cookies', 'en')).toBe('/cookies');
+  });
+
+  it('handles trailing slashes on translated-slug pages', () => {
+    expect(getAlternateUrl('/privacidad/', 'es')).toBe('/en/privacy');
+    expect(getAlternateUrl('/en/legal-notice/', 'en')).toBe('/aviso-legal');
+  });
 });
 
 describe('getBlogSlugFromId', () => {


### PR DESCRIPTION
## Summary

El selector de idioma hacía un swap mecánico de `/en` y mandaba a 404 desde las páginas legales con slug traducido (`/privacidad` ↔ `/en/privacy` y `/aviso-legal` ↔ `/en/legal-notice`). El \"fallo del banner\" del issue era consecuencia: en 404 la UI se ve rota.

## Fix

- `getAlternateUrl` ahora consulta un mapa explícito para slugs traducidos antes del swap mecánico. También normaliza trailing slashes.
- `/cookies` sigue funcionando porque comparte slug entre idiomas.

## Tests

Según pide el issue, cubro **una página de cada tipo**:
- Home (`/` ↔ `/en/`)
- Blog post (`/blog/*` ↔ `/en/blog/*`)
- CV (`/cv` ↔ `/en/cv`)
- Privacidad (`/privacidad` ↔ `/en/privacy`)
- Aviso Legal (`/aviso-legal` ↔ `/en/legal-notice`)
- Cookies (`/cookies` ↔ `/en/cookies`)

6 casos nuevos + los existentes. 135/135 verdes.

## Test plan
- [x] `npx vitest run` → 135/135.
- [x] `npm run build` → 0 errors.
- [ ] Dev: abrir `/privacidad` → clic en EN → aterriza en `/en/privacy` (no 404).
- [ ] Dev: abrir `/en/legal-notice` → clic en ES → aterriza en `/aviso-legal`.
- [ ] Dev: `/cookies` y `/en/cookies` siguen funcionando en ambas direcciones.
- [ ] Banner aparece con el idioma correcto tras cambiar desde el selector.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)