### PR TITLE
fix(a11y): resolver findings de Lighthouse (score 86 → ~97)

### DIFF
--- a/src/components/Footer/Footer.astro
+++ b/src/components/Footer/Footer.astro
@@ -35,17 +35,17 @@ const manageCookiesLabel = isES ? 'Gestionar cookies' : 'Manage cookies';
     <p class="font-mono text-[10px] uppercase tracking-[0.2em] text-quaternary/70 dark:text-slate-500">
         &copy; {new Date().getFullYear()} aitorevi · Crafted with Astro
     </p>
-    <nav class="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 font-mono text-[10px] uppercase tracking-[0.2em] text-quaternary/70 dark:text-slate-500" aria-label={isES ? 'Enlaces legales' : 'Legal links'}>
+    <nav class="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 font-mono text-[10px] uppercase tracking-[0.2em] text-slate-600 dark:text-slate-400" aria-label={isES ? 'Enlaces legales' : 'Legal links'}>
         {legalLinks.map((link, i) => (
             <>
-                {i > 0 && <span aria-hidden="true">·</span>}
-                <a href={link.href} class="hover:text-secondary dark:hover:text-accent-blue transition-colors duration-200">
+                {i > 0 && <span aria-hidden="true" class="select-none">·</span>}
+                <a href={link.href} class="inline-block px-2 py-2 hover:text-secondary dark:hover:text-accent-blue transition-colors duration-200">
                     {link.label}
                 </a>
             </>
         ))}
-        <span aria-hidden="true">·</span>
-        <button type="button" id="manage-cookies" class="hover:text-secondary dark:hover:text-accent-blue transition-colors duration-200 uppercase tracking-[0.2em]">
+        <span aria-hidden="true" class="select-none">·</span>
+        <button type="button" id="manage-cookies" class="inline-block px-2 py-2 uppercase tracking-[0.2em] hover:text-secondary dark:hover:text-accent-blue transition-colors duration-200">
             {manageCookiesLabel}
         </button>
     </nav>

--- a/src/components/analytics/CookieConsent.astro
+++ b/src/components/analytics/CookieConsent.astro
@@ -42,11 +42,11 @@ const copy = isES
       {copy.message}
       <br class="hidden md:block" />
       <span class="font-mono text-[11px] uppercase tracking-[0.15em]">
-        <a href={copy.moreInfoHref} class="text-secondary hover:text-accent-violet dark:text-accent-blue dark:hover:text-accent-violet underline-offset-2 hover:underline">
+        <a href={copy.moreInfoHref} class="text-secondary underline underline-offset-2 hover:text-accent-violet dark:text-accent-blue dark:hover:text-accent-violet">
           {copy.moreInfoLabel}
         </a>
         <span aria-hidden="true" class="mx-2 text-slate-400">·</span>
-        <a href={copy.privacyHref} class="text-secondary hover:text-accent-violet dark:text-accent-blue dark:hover:text-accent-violet underline-offset-2 hover:underline">
+        <a href={copy.privacyHref} class="text-secondary underline underline-offset-2 hover:text-accent-violet dark:text-accent-blue dark:hover:text-accent-violet">
           {copy.privacyLabel}
         </a>
       </span>

--- a/src/components/blog/BlogPage.astro
+++ b/src/components/blog/BlogPage.astro
@@ -76,7 +76,7 @@ const regularItemClass = regularPosts.length === 1
       <h1 class="mb-4 pb-2 font-display text-5xl font-black tracking-tight text-ink-900 dark:bg-home-gradient-text dark:bg-clip-text dark:text-transparent sm:text-6xl lg:text-7xl">
         Blog
       </h1>
-      <p class="mx-auto mt-3 max-w-xl font-mono text-xs uppercase tracking-[0.3em] text-secondary/70 dark:text-accent-blue/50">
+      <p class="mx-auto mt-3 max-w-xl font-mono text-xs uppercase tracking-[0.3em] text-secondary dark:text-accent-blue/80">
         {t(lang, 'blog.subtitle')}
       </p>
     </header>

--- a/src/components/cv/CvExperience.astro
+++ b/src/components/cv/CvExperience.astro
@@ -73,7 +73,7 @@ const items = entries.flatMap((entry) =>
 
           {/* Content column */}
           <div class:list={["reveal-right flex-1 pl-6", isLast ? "pb-0" : "pb-8"]}>
-            <span class="text-xs text-secondary/70 dark:text-accent-violet/75 font-semibold uppercase tracking-wider">{item.company} · {item.role}</span>
+            <span class="text-xs text-secondary dark:text-accent-violet/75 font-semibold uppercase tracking-wider">{item.company} · {item.role}</span>
             <strong class="block text-[0.95rem] leading-snug mt-0.5">{item.heading}</strong>
             {item.text && (
               <p class="text-sm text-slate-600 dark:text-slate-300 mt-1.5 leading-relaxed">{item.text}</p>

--- a/src/components/home/ContactSection.astro
+++ b/src/components/home/ContactSection.astro
@@ -35,7 +35,7 @@ const { lang } = Astro.props;
       >
         {t(lang, 'home.contact.title')}
       </h2>
-      <p class="mx-auto mt-3 max-w-xl font-mono text-xs uppercase tracking-[0.3em] text-secondary/85 dark:text-accent-blue/70">
+      <p class="mx-auto mt-3 max-w-xl font-mono text-xs uppercase tracking-[0.3em] text-secondary dark:text-accent-blue">
         {t(lang, 'home.contact.subtitle')}
       </p>
       <p class="mx-auto mt-6 max-w-xl text-sm leading-relaxed text-slate-600 dark:text-slate-400">
@@ -70,13 +70,13 @@ const { lang } = Astro.props;
         aria-hidden="true"
         style="position:absolute;left:-9999px;opacity:0;height:0;width:0;"
       />
-      <p class="mb-4 font-mono text-[10px] text-secondary/60 dark:text-accent-blue/50">
+      <p class="mb-4 font-mono text-[10px] text-secondary/80 dark:text-accent-blue/80">
         <span aria-hidden="true">* </span>{lang === 'es' ? 'Campos obligatorios' : 'Required fields'}
       </p>
 
       <div class="grid gap-5 sm:grid-cols-2">
         <label for="contact-name" class="block">
-          <span class="mb-2 block font-mono text-[10px] uppercase tracking-[0.2em] text-secondary/80 dark:text-accent-blue/60">
+          <span class="mb-2 block font-mono text-[10px] uppercase tracking-[0.2em] text-secondary/80 dark:text-accent-blue">
             {t(lang, 'home.contact.name')}<span aria-hidden="true"> *</span>
           </span>
           <input
@@ -94,7 +94,7 @@ const { lang } = Astro.props;
           <span id="contact-name-error" data-field-error="name" class="mt-1 hidden text-[11px] text-rose-400 font-mono" aria-live="polite"></span>
         </label>
         <label for="contact-email" class="block">
-          <span class="mb-2 block font-mono text-[10px] uppercase tracking-[0.2em] text-secondary/80 dark:text-accent-blue/60">
+          <span class="mb-2 block font-mono text-[10px] uppercase tracking-[0.2em] text-secondary/80 dark:text-accent-blue">
             {t(lang, 'home.contact.email')}<span aria-hidden="true"> *</span>
           </span>
           <input
@@ -114,7 +114,7 @@ const { lang } = Astro.props;
       </div>
 
       <label for="contact-subject" class="mt-5 block">
-        <span class="mb-2 block font-mono text-[10px] uppercase tracking-[0.2em] text-secondary/80 dark:text-accent-blue/60">
+        <span class="mb-2 block font-mono text-[10px] uppercase tracking-[0.2em] text-secondary/80 dark:text-accent-blue">
           {t(lang, 'home.contact.subject')}<span aria-hidden="true"> *</span>
         </span>
         <input
@@ -132,7 +132,7 @@ const { lang } = Astro.props;
       </label>
 
       <label for="contact-message" class="mt-5 block">
-        <span class="mb-2 block font-mono text-[10px] uppercase tracking-[0.2em] text-secondary/80 dark:text-accent-blue/60">
+        <span class="mb-2 block font-mono text-[10px] uppercase tracking-[0.2em] text-secondary/80 dark:text-accent-blue">
           {t(lang, 'home.contact.message')}<span aria-hidden="true"> *</span>
         </span>
         <textarea
@@ -151,7 +151,7 @@ const { lang } = Astro.props;
 
       <!-- RGPD — cláusula informativa básica -->
       <section class="mt-6 border-t border-slate-200/70 pt-4 dark:border-white/5" aria-labelledby="contact-privacy-heading">
-        <p id="contact-privacy-heading" class="mb-2 font-mono text-[10px] uppercase tracking-[0.2em] text-secondary/70 dark:text-accent-blue/50">
+        <p id="contact-privacy-heading" class="mb-2 font-mono text-[10px] uppercase tracking-[0.2em] text-secondary dark:text-accent-blue/80">
           {t(lang, 'home.contact.privacy.heading')}
         </p>
         <p class="text-[11px] leading-relaxed text-slate-500 dark:text-slate-500">
@@ -177,7 +177,7 @@ const { lang } = Astro.props;
         <span>
           {t(lang, 'home.contact.consent.label')}
           {' '}
-          <a href={lang === 'es' ? '/privacidad' : '/en/privacy'} class="text-secondary/80 hover:text-accent-violet dark:text-accent-blue/70 dark:hover:text-accent-violet underline-offset-2 hover:underline">
+          <a href={lang === 'es' ? '/privacidad' : '/en/privacy'} class="text-secondary underline underline-offset-2 hover:text-accent-violet dark:text-accent-blue dark:hover:text-accent-violet">
             {t(lang, 'home.contact.consent.linkLabel')}
           </a>
           <span aria-hidden="true"> *</span>

--- a/src/components/home/HeroParallax.astro
+++ b/src/components/home/HeroParallax.astro
@@ -134,7 +134,7 @@ const gridVLines = Array.from({ length: 16 }, (_, i) => i);
     -->
     <p
       transition:persist="hero-role-label"
-      class="mb-6 text-[11px] uppercase tracking-[0.5em] text-secondary/80 dark:text-accent-blue/70 font-mono"
+      class="mb-6 text-[11px] uppercase tracking-[0.5em] text-secondary/80 dark:text-accent-blue font-mono"
       data-hero-reveal
       style="--reveal-delay: 0ms"
     >
@@ -200,7 +200,7 @@ const gridVLines = Array.from({ length: 16 }, (_, i) => i);
       data-hero-scroll-hint
       aria-hidden="true"
     >
-      <span class="text-[10px] uppercase tracking-[0.3em] text-secondary/70 dark:text-accent-blue/60 font-mono">
+      <span class="text-[10px] uppercase tracking-[0.3em] text-secondary dark:text-accent-blue font-mono">
         Scroll
       </span>
       <span class="block h-10 w-px bg-gradient-to-b from-secondary/50 to-transparent dark:from-accent-blue/50"></span>

--- a/src/components/home/LatestPosts.astro
+++ b/src/components/home/LatestPosts.astro
@@ -46,7 +46,7 @@ const itemSizingClass = isSingle
       >
         {t(lang, 'home.posts.title')}
       </h2>
-      <p class="font-mono text-xs uppercase tracking-[0.3em] text-secondary/85 dark:text-accent-blue/70">
+      <p class="font-mono text-xs uppercase tracking-[0.3em] text-secondary dark:text-accent-blue">
         {t(lang, 'home.posts.subtitle')}
       </p>
     </div>

--- a/src/components/home/Portfolio.astro
+++ b/src/components/home/Portfolio.astro
@@ -53,7 +53,7 @@ const projects = [
       {t(lang, 'home.portfolio.title')}
     </h2>
     <p
-      class="mx-auto mt-3 max-w-xl text-center font-mono text-xs uppercase tracking-[0.3em] text-secondary/85 dark:text-accent-blue/70"
+      class="mx-auto mt-3 max-w-xl text-center font-mono text-xs uppercase tracking-[0.3em] text-secondary dark:text-accent-blue"
     >
       {t(lang, 'home.portfolio.subtitle')}
     </p>
@@ -93,7 +93,7 @@ const projects = [
               {t(lang, project.descKey)}
             </p>
 
-            <p class="mt-3 font-mono text-[11px] text-secondary/60 dark:text-accent-violet/50">
+            <p class="mt-3 font-mono text-[11px] text-secondary/80 dark:text-accent-violet/80">
               {project.tech}
             </p>
           </div>

--- a/src/components/home/StatsCounter.astro
+++ b/src/components/home/StatsCounter.astro
@@ -52,7 +52,7 @@ const stats = [
       {t(lang, 'home.stats.title')}
     </h2>
     <p
-      class="mx-auto mt-3 max-w-xl text-center font-mono text-xs uppercase tracking-[0.3em] text-secondary/85 dark:text-accent-blue/70"
+      class="mx-auto mt-3 max-w-xl text-center font-mono text-xs uppercase tracking-[0.3em] text-secondary dark:text-accent-blue"
     >
       {t(lang, 'home.stats.subtitle')}
     </p>
@@ -81,7 +81,7 @@ const stats = [
           >
             {stat.suffix ? '0' : stat.value}
           </div>
-          <div class="relative mt-3 font-mono text-[11px] uppercase tracking-[0.25em] text-secondary/85 dark:text-accent-violet/70 group-hover:dark:text-accent-violet/80 transition-colors">
+          <div class="relative mt-3 font-mono text-[11px] uppercase tracking-[0.25em] text-secondary dark:text-accent-violet/70 group-hover:dark:text-accent-violet/80 transition-colors">
             {t(lang, stat.labelKey)}
           </div>
         </div>

--- a/src/components/home/Talks.astro
+++ b/src/components/home/Talks.astro
@@ -33,7 +33,7 @@ const itemSizingClass = isSingle
       {t(lang, 'home.talks.title')}
     </h2>
     <p
-      class="mx-auto mt-3 max-w-xl text-center font-mono text-xs uppercase tracking-[0.3em] text-secondary/85 dark:text-accent-blue/70"
+      class="mx-auto mt-3 max-w-xl text-center font-mono text-xs uppercase tracking-[0.3em] text-secondary dark:text-accent-blue"
     >
       {t(lang, 'home.talks.subtitle')}
     </p>
@@ -82,7 +82,7 @@ const itemSizingClass = isSingle
               </p>
             )}
 
-            <p class="mt-3 font-mono text-[11px] uppercase tracking-[0.15em] text-secondary/70 dark:text-accent-blue/60">
+            <p class="mt-3 font-mono text-[11px] uppercase tracking-[0.15em] text-secondary dark:text-accent-blue">
               {talk.event} · <time datetime={formatDateISO(talk.date)}>{formatDate(talk.date, locale)}</time>
             </p>
 

--- a/src/components/home/TechStack.astro
+++ b/src/components/home/TechStack.astro
@@ -23,7 +23,7 @@ const { lang } = Astro.props;
     >
       {t(lang, 'home.stack.title')}
     </h2>
-    <p class="mx-auto mt-3 max-w-xl text-center font-mono text-xs uppercase tracking-[0.3em] text-secondary/85 dark:text-accent-blue/70">
+    <p class="mx-auto mt-3 max-w-xl text-center font-mono text-xs uppercase tracking-[0.3em] text-secondary dark:text-accent-blue">
       {t(lang, 'home.stack.hint')}
     </p>
 

--- a/src/components/home/Testimonials.astro
+++ b/src/components/home/Testimonials.astro
@@ -54,7 +54,7 @@ const testimonials = lang === 'es'
     >
       {t(lang, 'home.testimonials.title')}
     </h2>
-    <p class="mt-3 font-mono text-xs uppercase tracking-[0.3em] text-secondary/85 dark:text-accent-blue/70">
+    <p class="mt-3 font-mono text-xs uppercase tracking-[0.3em] text-secondary dark:text-accent-blue">
       {t(lang, 'home.testimonials.subtitle')}
     </p>
   </div>
@@ -105,7 +105,7 @@ const testimonials = lang === 'es'
                   }
                   <div>
                     <p class="text-sm font-semibold text-ink-900 dark:text-slate-100">{item.author}</p>
-                    <p class="font-mono text-[11px] text-secondary/60 dark:text-accent-violet/50 whitespace-nowrap">{item.role}</p>
+                    <p class="font-mono text-[11px] text-secondary/80 dark:text-accent-violet/80 whitespace-nowrap">{item.role}</p>
                   </div>
                 </a>
               ) : (
@@ -116,7 +116,7 @@ const testimonials = lang === 'es'
                   }
                   <div>
                     <p class="text-sm font-semibold text-ink-900 dark:text-slate-100">{item.author}</p>
-                    <p class="font-mono text-[11px] text-secondary/60 dark:text-accent-violet/50 whitespace-nowrap">{item.role}</p>
+                    <p class="font-mono text-[11px] text-secondary/80 dark:text-accent-violet/80 whitespace-nowrap">{item.role}</p>
                   </div>
                 </div>
               )}

--- a/src/components/home/WhatIDo.astro
+++ b/src/components/home/WhatIDo.astro
@@ -76,7 +76,7 @@ const cards = [
       {t(lang, 'home.whatIDo.title')}
     </h2>
     <p
-      class="mx-auto mt-3 max-w-xl text-center font-mono text-xs uppercase tracking-[0.3em] text-secondary/85 dark:text-accent-blue/70"
+      class="mx-auto mt-3 max-w-xl text-center font-mono text-xs uppercase tracking-[0.3em] text-secondary dark:text-accent-blue"
     >
       {t(lang, 'home.whatIDo.subtitle')}
     </p>

--- a/src/components/katas/KataCard.astro
+++ b/src/components/katas/KataCard.astro
@@ -36,7 +36,7 @@ const formattedDate = new Date(kata.date).toLocaleDateString(dateLocale, {
           <span class="sr-only"> — {t(lang, 'katas.card.openOnGithub')}</span>
         </a>
       </h3>
-      <p class="mt-1 font-mono text-[11px] uppercase tracking-[0.25em] text-secondary/80 dark:text-accent-blue/70">
+      <p class="mt-1 font-mono text-[11px] uppercase tracking-[0.25em] text-secondary/80 dark:text-accent-blue">
         {formattedDate}
       </p>
     </div>
@@ -53,7 +53,7 @@ const formattedDate = new Date(kata.date).toLocaleDateString(dateLocale, {
     {kata.concepts.length > 0 && (
       <ul class="flex flex-wrap gap-x-3 gap-y-1 font-mono text-[11px] tracking-wide text-quaternary/80 dark:text-slate-400">
         {kata.concepts.map((label) => (
-          <li class="before:mr-0.5 before:text-secondary/60 before:content-['#'] dark:before:text-accent-blue/60">
+          <li class="before:mr-0.5 before:text-secondary/80 before:content-['#'] dark:before:text-accent-blue/60">
             {label}
           </li>
         ))}

--- a/src/components/katas/KatasPage.astro
+++ b/src/components/katas/KatasPage.astro
@@ -36,7 +36,7 @@ const techs = [...techFrequency.entries()]
       <h1 class="mb-4 pb-2 font-display text-5xl font-black tracking-tight text-ink-900 dark:bg-home-gradient-text dark:bg-clip-text dark:text-transparent sm:text-6xl lg:text-7xl">
         {t(lang, 'katas.title')}
       </h1>
-      <p class="mx-auto mt-3 max-w-xl font-mono text-xs uppercase tracking-[0.3em] text-secondary/70 dark:text-accent-blue/50">
+      <p class="mx-auto mt-3 max-w-xl font-mono text-xs uppercase tracking-[0.3em] text-secondary dark:text-accent-blue/80">
         {t(lang, 'katas.subtitle')}
       </p>
       <p class="mx-auto mt-4 max-w-2xl text-base text-slate-600 dark:text-slate-300 sm:text-lg">

--- a/src/components/molecules/PostCard.astro
+++ b/src/components/molecules/PostCard.astro
@@ -146,11 +146,11 @@ const postUrl = lang === 'en' ? `/en/blog/${slug}` : `/blog/${slug}`;
   <div class="flex flex-1 flex-col p-6">
     <!-- Header: Tags -->
     <header class="mb-3">
-      <div class="flex flex-wrap gap-2" role="list" aria-label="Post tags">
+      <ul class="flex flex-wrap gap-2 list-none p-0" aria-label="Post tags">
         {data.tags.slice(0, 3).map((tag) => (
-          <Tag label={tag} variant="accent" />
+          <li><Tag label={tag} variant="accent" /></li>
         ))}
-      </div>
+      </ul>
     </header>
 
     <!-- Main Content -->

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -43,26 +43,13 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `https://www.aitorevi.
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
-		<!-- Fonts: JetBrains Mono (code/accents) + Outfit (display) — loaded async to avoid blocking render -->
+		<!-- Fonts: JetBrains Mono (code/accents) + Outfit (display) -->
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link
-			rel="preload"
-			as="style"
-			href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=Outfit:wght@600;700;900&display=swap"
-		/>
-		<link
 			rel="stylesheet"
 			href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=Outfit:wght@600;700;900&display=swap"
-			media="print"
-			onload="this.media='all'"
 		/>
-		<noscript>
-			<link
-				rel="stylesheet"
-				href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=Outfit:wght@600;700;900&display=swap"
-			/>
-		</noscript>
 		{alternateUrl && alternateLang && (
 			<link rel="alternate" hreflang={alternateLang} href={alternateUrl} />
 		)}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -43,13 +43,26 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `https://www.aitorevi.
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
-		<!-- Fonts: JetBrains Mono (code/accents) + Outfit (display) -->
+		<!-- Fonts: JetBrains Mono (code/accents) + Outfit (display) — loaded async to avoid blocking render -->
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link
-			rel="stylesheet"
+			rel="preload"
+			as="style"
 			href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=Outfit:wght@600;700;900&display=swap"
 		/>
+		<link
+			rel="stylesheet"
+			href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=Outfit:wght@600;700;900&display=swap"
+			media="print"
+			onload="this.media='all'"
+		/>
+		<noscript>
+			<link
+				rel="stylesheet"
+				href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=Outfit:wght@600;700;900&display=swap"
+			/>
+		</noscript>
 		{alternateUrl && alternateLang && (
 			<link rel="alternate" hreflang={alternateLang} href={alternateUrl} />
 		)}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -166,11 +166,11 @@ const coverImageAbsolute = toAbsoluteUrl(coverImageUrl);
     <!-- Article Header -->
     <header class="mb-8 space-y-4">
       <!-- Tags -->
-      <div class="flex flex-wrap gap-2" role="list" aria-label="Article tags">
+      <ul class="flex flex-wrap gap-2 list-none p-0" aria-label="Article tags">
         {data.tags.map((tag) => (
-          <Tag label={tag} variant="accent" />
+          <li><Tag label={tag} variant="accent" /></li>
         ))}
-      </div>
+      </ul>
 
       <!-- Title -->
       <h1

--- a/src/pages/en/blog/[...slug].astro
+++ b/src/pages/en/blog/[...slug].astro
@@ -117,11 +117,11 @@ const coverImageAbsolute = toAbsoluteUrl(coverImageUrl);
     itemtype="https://schema.org/BlogPosting"
   >
     <header class="mb-8 space-y-4">
-      <div class="flex flex-wrap gap-2" role="list" aria-label="Article tags">
+      <ul class="flex flex-wrap gap-2 list-none p-0" aria-label="Article tags">
         {data.tags.map((tag) => (
-          <Tag label={tag} variant="accent" />
+          <li><Tag label={tag} variant="accent" /></li>
         ))}
-      </div>
+      </ul>
       <h1
         class="text-4xl font-display font-bold leading-tight text-ink-900 dark:text-slate-100 sm:text-5xl lg:text-6xl"
         itemprop="headline"


### PR DESCRIPTION
## Summary

Lighthouse en / reportaba accesibilidad 86 con cuatro grupos de issues. Esta rama los aborda todos:

1. **Contraste insuficiente** — \`text-secondary/85\`, \`/70\`, \`/60\`, \`/50\` y sus variantes dark \`accent-blue/70..50\` / \`accent-violet/60..50\` incumplían el ratio 4.5:1 para texto pequeño. Bulk replace a tonos más fuertes en 13 componentes.
2. **Links distinguidos solo por color** — banner de cookies y link a Política de Privacidad del formulario pasaban con \`hover:underline\`. Ahora \`underline\` permanente.
3. **ARIA role=\"list\" sin listitem children** — las filas de tags del blog usaban \`<div role=\"list\">\` con \`<Tag>\` hijos (span). Reemplazado por \`<ul>\` + \`<li>\` wrapping (semántica nativa).
4. **Touch targets pequeños** — legal links del footer y botón \"Gestionar cookies\" eran sub-24px. Añadido \`inline-block px-2 py-2\` (~40px hit area) y color con más contraste.

Incluye un pequeño revert del primer intento de cargar Google Fonts async que rompía estilos — ese trabajo sigue en la rama \`perf/self-host-fonts\` mergeada aparte.

## Test plan
- [x] \`npm run build\` → 0 errors.
- [x] \`npm test\` → 135/135 verdes.
- [ ] Tras deploy: Lighthouse A11y en producción ≥ 95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)