### PR TITLE
fix(consent): explicit cookie gate on GA page_view

### DIFF
--- a/src/components/analytics/CookieConsent.astro
+++ b/src/components/analytics/CookieConsent.astro
@@ -93,6 +93,15 @@ const copy = isES
       });
     }
 
+    function trackPageViewAfterConsent() {
+      if (typeof window.gtag !== 'function') return;
+      window.gtag('event', 'page_view', {
+        page_title: document.title,
+        page_location: window.location.href,
+        page_path: window.location.pathname + window.location.search,
+      });
+    }
+
     function init() {
       var banner = document.getElementById('cookie-consent');
       if (!banner) return;
@@ -106,6 +115,10 @@ const copy = isES
         btn.addEventListener('click', function () {
           writeConsent('granted');
           updateGtag('granted');
+          // Fire a page_view for the current page now that we have consent —
+          // trackPageView in GoogleAnalytics.astro gated on consent, so the
+          // initial astro:page-load hit was suppressed.
+          trackPageViewAfterConsent();
           banner.hidden = true;
         });
       });

--- a/src/components/analytics/GoogleAnalytics.astro
+++ b/src/components/analytics/GoogleAnalytics.astro
@@ -47,7 +47,16 @@ const shouldLoad = Boolean(id) && !isExcluded;
     // Safety net: passive readers who never interact still get tracked.
     setTimeout(loadGtag, 8000);
 
+    function readConsent() {
+      return (document.cookie.match(/(?:^|; )aitorevi_consent=(granted|denied)/) || [])[1];
+    }
+
     function trackPageView() {
+      // Belt-and-suspenders gate on top of Consent Mode v2: only queue
+      // the page_view if the user has explicitly accepted. Pending and
+      // rejected visitors never fire a hit, regardless of gtag's
+      // internal consent handling.
+      if (readConsent() !== 'granted') return;
       gtag('event', 'page_view', {
         page_title: document.title,
         page_location: window.location.href,


### PR DESCRIPTION
## Summary

Problema reportado: al hacer scroll, GA dispara hits incluso si el usuario no ha aceptado el banner de cookies. Causa probable: Consent Mode v2 envía \"cookieless pings\" con \`gcs=G000\` flags incluso cuando denegado, que en DevTools/Network aparecen como page_view fired.

## Fix

\`trackPageView\` en \`GoogleAnalytics.astro\` ahora tiene una gate explícita: lee el cookie \`aitorevi_consent\` y NO emite el evento si el valor no es \`'granted'\`. No depende de cómo gtag.js interprete Consent Mode v2.

Lado efecto: si el usuario acepta DESPUÉS del page load, el listener original ya había corrido sin consent → page_view perdido. Para compensar, \`CookieConsent.astro\` en su handler de \"Aceptar\" dispara un page_view manual tras el \`gtag('consent', 'update')\`.

## Test plan

Escenarios a verificar tras deploy:

1. **Primera visita (sin cookie)**:
   - Abrir home en incógnito → scrollear.
   - Network filtrando \`collect\`: **NO hits**.
   - Clicar \"Aceptar\" en banner.
   - Network: **1 hit** con page_view inmediato.

2. **Segunda visita tras Rechazar**:
   - Cookie = \`denied\`.
   - Scrollear → **NO hits**.

3. **Segunda visita tras Aceptar previamente**:
   - Cookie = \`granted\`.
   - Scrollear → **1 hit** al hacer scroll (defer sigue funcionando).
   - Navegar a /blog (view transition) → **1 hit** en nueva ruta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)