### PR TITLE
feat(case-study): auto-fetch Numbers stats at build time

### DIFF
--- a/src/components/case-study/SelfPage.astro
+++ b/src/components/case-study/SelfPage.astro
@@ -5,6 +5,7 @@ import { Icon } from 'astro-icon/components';
 import { t } from '../../i18n/utils';
 import type { Lang } from '../../data/cv';
 import pkg from '../../../package.json';
+import { fetchBuildStats } from '../../lib/build-stats';
 
 interface Props {
   lang: Lang;
@@ -29,18 +30,18 @@ const buildBlogPostPath = (slug: string) => (isES ? `/blog/${slug}` : `/en/blog/
 const timelineItems = [1, 2, 3, 4, 5] as const;
 const decisions = ['astro', 'i18n', 'cms', 'consent', 'tests', 'ci', 'a11y'] as const;
 
-// Stat tiles. Data collected from git/gh on 2026-04-23.
-// See docs/case-study-research.md for methodology.
-// `static: true` means "render as-is, skip the count-up" — only used for
-// the year, where a 0 → 2024 tween would read like a clock spinning.
+const buildStats = fetchBuildStats(new URL('../../../', import.meta.url).pathname);
+
+// `static: true` skips the count-up tween — used for the year so it
+// doesn't spin from 0 → 2024 on every page load.
 const stats = [
-  { value: 416, labelKey: 'portfolio.self.numbers.commits' },
-  { value: 47, labelKey: 'portfolio.self.numbers.prs' },
-  { value: 135, labelKey: 'portfolio.self.numbers.tests' },
-  { value: 2, labelKey: 'portfolio.self.numbers.languages' },
-  { value: 6, labelKey: 'portfolio.self.numbers.legalPages' },
-  { value: 2, labelKey: 'portfolio.self.numbers.workflows' },
-  { value: 2024, labelKey: 'portfolio.self.numbers.since', static: true },
+  { value: buildStats.commits,    labelKey: 'portfolio.self.numbers.commits' },
+  { value: buildStats.prs,        labelKey: 'portfolio.self.numbers.prs' },
+  { value: buildStats.tests,      labelKey: 'portfolio.self.numbers.tests' },
+  { value: 2,                     labelKey: 'portfolio.self.numbers.languages' },
+  { value: buildStats.legalPages, labelKey: 'portfolio.self.numbers.legalPages' },
+  { value: buildStats.workflows,  labelKey: 'portfolio.self.numbers.workflows' },
+  { value: 2024,                  labelKey: 'portfolio.self.numbers.since', static: true },
 ];
 
 // Lighthouse / PageSpeed Insights scores (mobile, measured on

--- a/src/lib/build-stats.ts
+++ b/src/lib/build-stats.ts
@@ -1,0 +1,35 @@
+import { execSync } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+function run(cmd: string, fallback: number): number {
+  try {
+    const raw = execSync(cmd, { encoding: 'utf8', shell: true }).trim();
+    const n = parseInt(raw, 10);
+    return Number.isFinite(n) && n > 0 ? n : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function countLegalPages(root: string): number {
+  const legalSlugs = ['aviso-legal', 'privacidad', 'cookies', 'legal-notice', 'privacy'];
+  let count = 0;
+  for (const dir of [join(root, 'src/pages'), join(root, 'src/pages/en')]) {
+    try {
+      const files = readdirSync(dir);
+      count += files.filter((f) => legalSlugs.some((s) => f.startsWith(s))).length;
+    } catch { /* dir missing */ }
+  }
+  return count || 6;
+}
+
+export function fetchBuildStats(root: string) {
+  return {
+    commits:      run('git rev-list --count HEAD', 416),
+    prs:          run('gh pr list --state all --limit 1000 --json number --jq length', 47),
+    tests:        run("grep -rE '^\\s*(it|test)\\(' tests/ --include='*.ts' | wc -l | tr -d ' '", 135),
+    workflows:    run('ls .github/workflows/*.yml 2>/dev/null | wc -l | tr -d " "', 2),
+    legalPages:   countLegalPages(root),
+  };
+}


### PR DESCRIPTION
## Summary

- New `src/lib/build-stats.ts` runs `git rev-list`, `gh pr list`, grep on tests, and `ls` on workflows at build time
- `SelfPage.astro` uses these live values instead of hardcoded numbers
- Each stat has a numeric fallback in case the command is unavailable (no `gh` auth in CI, etc.)
- Verified: commits 414, PRs 56, tests 135, workflows 2, legal pages 6

## Test plan
- [ ] `npm run build` passes
- [ ] `data-stat-target` values in `dist/client/portfolio/aitorevi-dev/index.html` match `git rev-list --count HEAD` and `gh pr list --state all --json number --jq length`

🤖 Generated with [Claude Code](https://claude.com/claude-code)