### PR TITLE
refactor: replace relative imports with @/ path alias, closes #105

### DIFF
--- a/src/components/analytics/CookieConsent.astro
+++ b/src/components/analytics/CookieConsent.astro
@@ -1,5 +1,5 @@
 ---
-import { getLangFromUrl } from '../../i18n/utils';
+import { getLangFromUrl } from '@/i18n/utils';
 
 const lang = getLangFromUrl(Astro.url);
 const isES = lang === 'es';

--- a/src/components/blog/BlogContent.astro
+++ b/src/components/blog/BlogContent.astro
@@ -1,12 +1,12 @@
 ---
 import { getCollection } from 'astro:content';
-import Layout from '../../layouts/Layout.astro';
+import Layout from '@/layouts/Layout.astro';
 import PostCard from './PostCard.astro';
-import DotField from '../shared/DotField.astro';
-import Button from '../shared/Button.astro';
-import { sortPostsByDate, filterDrafts } from '../../lib/blog';
-import { t, getBlogSlugFromId, getLocalePath } from '../../i18n/utils';
-import type { Lang } from '../../i18n/types';
+import DotField from '@/components/shared/DotField.astro';
+import Button from '@/components/shared/Button.astro';
+import { sortPostsByDate, filterDrafts } from '@/lib/blog';
+import { t, getBlogSlugFromId, getLocalePath } from '@/i18n/utils';
+import type { Lang } from '@/i18n/types';
 
 interface Props {
   lang: Lang;

--- a/src/components/blog/CodeBlockEnhancer.astro
+++ b/src/components/blog/CodeBlockEnhancer.astro
@@ -13,9 +13,9 @@
  * `#article-content` (the script reads its `data-code-block-label`).
  */
 
-import CopyButton from '../shared/CopyButton.astro';
-import { t } from '../../i18n/utils';
-import type { Lang } from '../../i18n/types';
+import CopyButton from '@/components/shared/CopyButton.astro';
+import { t } from '@/i18n/utils';
+import type { Lang } from '@/i18n/types';
 
 interface Props {
   lang: Lang;

--- a/src/components/blog/PostCard.astro
+++ b/src/components/blog/PostCard.astro
@@ -31,12 +31,12 @@
 
 import type { CollectionEntry } from 'astro:content';
 import { Image } from 'astro:assets';
-import Tag from '../shared/Tag.astro';
-import DateDisplay from '../shared/DateDisplay.astro';
-import ReadingTime from '../shared/ReadingTime.astro';
-import { calculateReadingTime } from '../../lib/blog';
-import { formatDate } from '../../lib/date';
-import { t, getBlogSlugFromId } from '../../i18n/utils';
+import Tag from '@/components/shared/Tag.astro';
+import DateDisplay from '@/components/shared/DateDisplay.astro';
+import ReadingTime from '@/components/shared/ReadingTime.astro';
+import { calculateReadingTime } from '@/lib/blog';
+import { formatDate } from '@/lib/date';
+import { t, getBlogSlugFromId } from '@/i18n/utils';
 
 interface Props {
   /**

--- a/src/components/case-study/ImsContent.astro
+++ b/src/components/case-study/ImsContent.astro
@@ -1,6 +1,6 @@
 ---
-import Layout from '../../layouts/Layout.astro';
-import { t } from '../../i18n/utils';
+import Layout from '@/layouts/Layout.astro';
+import { t } from '@/i18n/utils';
 
 const lang = 'es';
 

--- a/src/components/case-study/SelfContent.astro
+++ b/src/components/case-study/SelfContent.astro
@@ -1,12 +1,12 @@
 ---
-import Layout from '../../layouts/Layout.astro';
-import Button from '../shared/Button.astro';
-import { t } from '../../i18n/utils';
-import type { Lang } from '../../i18n/types';
-import { fetchBuildStats } from '../../lib/build-time/build-stats';
-import StatCard from '../shared/StatCard.astro';
-import SectionHeader from '../shared/SectionHeader.astro';
-import EyebrowTag from '../shared/EyebrowTag.astro';
+import Layout from '@/layouts/Layout.astro';
+import Button from '@/components/shared/Button.astro';
+import { t } from '@/i18n/utils';
+import type { Lang } from '@/i18n/types';
+import { fetchBuildStats } from '@/lib/build-time/build-stats';
+import StatCard from '@/components/shared/StatCard.astro';
+import SectionHeader from '@/components/shared/SectionHeader.astro';
+import EyebrowTag from '@/components/shared/EyebrowTag.astro';
 import DecisionCard from './DecisionCard.astro';
 import StackCategory from './StackCategory.astro';
 import ScoreBadge from './ScoreBadge.astro';

--- a/src/components/cv/CvCertifications.astro
+++ b/src/components/cv/CvCertifications.astro
@@ -1,5 +1,5 @@
 ---
-import type { CertificationEntry } from '../../data/cv';
+import type { CertificationEntry } from '@/data/cv';
 import CvSectionTitle from './CvSectionTitle.astro';
 import CertificationCard from './CertificationCard.astro';
 

--- a/src/components/cv/CvContent.astro
+++ b/src/components/cv/CvContent.astro
@@ -1,5 +1,5 @@
 ---
-import Layout from '../../layouts/Layout.astro';
+import Layout from '@/layouts/Layout.astro';
 import CvHeader from './CvHeader.astro';
 import CvProfile from './CvProfile.astro';
 import CvExperience from './CvExperience.astro';
@@ -8,9 +8,9 @@ import CvEducation from './CvEducation.astro';
 import CvCertifications from './CvCertifications.astro';
 import CvPdfDownload from './CvPdfDownload.astro';
 import CvScrollReveal from './CvScrollReveal.astro';
-import DotField from '../shared/DotField.astro';
-import { getCvData, getPdfPath, getJsonPath } from '../../data/cv';
-import type { Lang } from '../../i18n/types';
+import DotField from '@/components/shared/DotField.astro';
+import { getCvData, getPdfPath, getJsonPath } from '@/data/cv';
+import type { Lang } from '@/i18n/types';
 
 interface Props {
   lang: Lang;

--- a/src/components/cv/CvEducation.astro
+++ b/src/components/cv/CvEducation.astro
@@ -1,5 +1,5 @@
 ---
-import type { EducationEntry } from '../../data/cv';
+import type { EducationEntry } from '@/data/cv';
 import CvSectionTitle from './CvSectionTitle.astro';
 
 interface Props {

--- a/src/components/cv/CvExperience.astro
+++ b/src/components/cv/CvExperience.astro
@@ -1,7 +1,7 @@
 ---
-import type { ExperienceEntry } from '../../data/cv';
+import type { ExperienceEntry } from '@/data/cv';
 import CvExperienceItem from './CvExperienceItem.astro';
-import Tag from '../shared/Tag.astro';
+import Tag from '@/components/shared/Tag.astro';
 import CvSectionTitle from './CvSectionTitle.astro';
 
 interface Props {

--- a/src/components/cv/CvExperienceItem.astro
+++ b/src/components/cv/CvExperienceItem.astro
@@ -1,6 +1,6 @@
 ---
-import type { ExperienceEntry } from '../../data/cv';
-import Tag from '../shared/Tag.astro';
+import type { ExperienceEntry } from '@/data/cv';
+import Tag from '@/components/shared/Tag.astro';
 
 interface Props {
   entry: ExperienceEntry;

--- a/src/components/cv/CvHeader.astro
+++ b/src/components/cv/CvHeader.astro
@@ -1,7 +1,7 @@
 ---
 import { Icon } from 'astro-icon/components';
-import type { ContactInfo } from '../../data/cv';
-import { getLangFromUrl, getLocalePath } from '../../i18n/utils';
+import type { ContactInfo } from '@/data/cv';
+import { getLangFromUrl, getLocalePath } from '@/i18n/utils';
 
 interface Props {
   contact: ContactInfo;

--- a/src/components/cv/CvPdfDownload.astro
+++ b/src/components/cv/CvPdfDownload.astro
@@ -1,6 +1,6 @@
 ---
 import { Icon } from 'astro-icon/components';
-import Button from '../shared/Button.astro';
+import Button from '@/components/shared/Button.astro';
 
 interface Props {
   pdfPath: string;

--- a/src/components/cv/CvPrintLayout.astro
+++ b/src/components/cv/CvPrintLayout.astro
@@ -12,8 +12,8 @@
  * - Zero decorative elements: no dots, borders, shadows, icons
  * - Skills rendered as inline comma-separated lists to save vertical space
  */
-import type { CvData } from '../../data/cv';
-import type { Lang } from '../../i18n/types';
+import type { CvData } from '@/data/cv';
+import type { Lang } from '@/i18n/types';
 
 interface Props {
   data: CvData;

--- a/src/components/cv/CvSkillCategory.astro
+++ b/src/components/cv/CvSkillCategory.astro
@@ -1,6 +1,6 @@
 ---
-import type { SkillCategoryData } from '../../data/cv';
-import Tag from '../shared/Tag.astro';
+import type { SkillCategoryData } from '@/data/cv';
+import Tag from '@/components/shared/Tag.astro';
 
 interface Props {
   category: SkillCategoryData;

--- a/src/components/cv/CvSkills.astro
+++ b/src/components/cv/CvSkills.astro
@@ -1,5 +1,5 @@
 ---
-import type { SkillCategoryData } from '../../data/cv';
+import type { SkillCategoryData } from '@/data/cv';
 import CvSkillCategory from './CvSkillCategory.astro';
 import CvSectionTitle from './CvSectionTitle.astro';
 

--- a/src/components/footer/Footer.astro
+++ b/src/components/footer/Footer.astro
@@ -1,6 +1,6 @@
 ---
 import {Icon} from "astro-icon/components";
-import { getLangFromUrl, getLocalePath } from '../../i18n/utils';
+import { getLangFromUrl, getLocalePath } from '@/i18n/utils';
 
 const lang = getLangFromUrl(Astro.url);
 const isES = lang === 'es';

--- a/src/components/home/ContactSection.astro
+++ b/src/components/home/ContactSection.astro
@@ -10,10 +10,10 @@
  * (id="contact").
  */
 import { Icon } from 'astro-icon/components';
-import type { Lang } from '../../i18n/types';
-import { t } from '../../i18n/utils';
-import Button from '../shared/Button.astro';
-import SectionHeader from '../shared/SectionHeader.astro';
+import type { Lang } from '@/i18n/types';
+import { t } from '@/i18n/utils';
+import Button from '@/components/shared/Button.astro';
+import SectionHeader from '@/components/shared/SectionHeader.astro';
 
 interface Props {
   lang: Lang;

--- a/src/components/home/HeroParallax.astro
+++ b/src/components/home/HeroParallax.astro
@@ -22,8 +22,8 @@
  * Dot field positions are generated at build time for stability across renders.
  */
 
-import type { Lang } from '../../i18n/types';
-import { t } from '../../i18n/utils';
+import type { Lang } from '@/i18n/types';
+import { t } from '@/i18n/utils';
 
 interface Props {
   lang: Lang;

--- a/src/components/home/HomeContent.astro
+++ b/src/components/home/HomeContent.astro
@@ -7,7 +7,7 @@
  * variants, and the Layout/Nav behave normally over the top. Individual
  * sections handle their own animations, parallax and IntersectionObservers.
  */
-import type { Lang } from '../../i18n/types';
+import type { Lang } from '@/i18n/types';
 import HeroParallax from './HeroParallax.astro';
 import WhatIDo from './WhatIDo.astro';
 import StatsCounter from './StatsCounter.astro';

--- a/src/components/home/LatestPosts.astro
+++ b/src/components/home/LatestPosts.astro
@@ -8,11 +8,11 @@
  * just rendering what's available.
  */
 import { getCollection } from 'astro:content';
-import PostCard from '../blog/PostCard.astro';
-import SectionHeader from '../shared/SectionHeader.astro';
-import { sortPostsByDate, filterDrafts } from '../../lib/blog';
-import { t } from '../../i18n/utils';
-import type { Lang } from '../../i18n/types';
+import PostCard from '@/components/blog/PostCard.astro';
+import SectionHeader from '@/components/shared/SectionHeader.astro';
+import { sortPostsByDate, filterDrafts } from '@/lib/blog';
+import { t } from '@/i18n/utils';
+import type { Lang } from '@/i18n/types';
 
 interface Props {
   lang: Lang;

--- a/src/components/home/Portfolio.astro
+++ b/src/components/home/Portfolio.astro
@@ -1,9 +1,9 @@
 ---
-import type { Lang } from '../../i18n/types';
-import { t } from '../../i18n/utils';
-import SectionHeader from '../shared/SectionHeader.astro';
-import EyebrowTag from '../shared/EyebrowTag.astro';
-import GlassCard from '../shared/GlassCard.astro';
+import type { Lang } from '@/i18n/types';
+import { t } from '@/i18n/utils';
+import SectionHeader from '@/components/shared/SectionHeader.astro';
+import EyebrowTag from '@/components/shared/EyebrowTag.astro';
+import GlassCard from '@/components/shared/GlassCard.astro';
 
 interface Props {
   lang: Lang;

--- a/src/components/home/ServiceCard.astro
+++ b/src/components/home/ServiceCard.astro
@@ -1,5 +1,5 @@
 ---
-import GlassCard from '../shared/GlassCard.astro';
+import GlassCard from '@/components/shared/GlassCard.astro';
 
 interface Props {
   icon: string;

--- a/src/components/home/StatsCounter.astro
+++ b/src/components/home/StatsCounter.astro
@@ -9,10 +9,10 @@
  * Single IntersectionObserver, one rAF loop per counter, cleans itself up.
  * Respects prefers-reduced-motion (shows final value immediately).
  */
-import type { Lang } from '../../i18n/types';
-import { t } from '../../i18n/utils';
-import StatCard from '../shared/StatCard.astro';
-import SectionHeader from '../shared/SectionHeader.astro';
+import type { Lang } from '@/i18n/types';
+import { t } from '@/i18n/utils';
+import StatCard from '@/components/shared/StatCard.astro';
+import SectionHeader from '@/components/shared/SectionHeader.astro';
 
 interface Props {
   lang: Lang;

--- a/src/components/home/Talks.astro
+++ b/src/components/home/Talks.astro
@@ -1,11 +1,11 @@
 ---
-import type { Lang } from '../../i18n/types';
-import { t } from '../../i18n/utils';
-import { talks } from '../../data/talks';
-import { formatDate, formatDateISO } from '../../lib/date';
-import SectionHeader from '../shared/SectionHeader.astro';
-import EyebrowTag from '../shared/EyebrowTag.astro';
-import GlassCard from '../shared/GlassCard.astro';
+import type { Lang } from '@/i18n/types';
+import { t } from '@/i18n/utils';
+import { talks } from '@/data/talks';
+import { formatDate, formatDateISO } from '@/lib/date';
+import SectionHeader from '@/components/shared/SectionHeader.astro';
+import EyebrowTag from '@/components/shared/EyebrowTag.astro';
+import GlassCard from '@/components/shared/GlassCard.astro';
 
 interface Props {
   lang: Lang;

--- a/src/components/home/TechStack.astro
+++ b/src/components/home/TechStack.astro
@@ -4,10 +4,10 @@
  * Hydrated with client:visible so the interactive JS only loads when the
  * section actually enters the viewport.
  */
-import type { Lang } from '../../i18n/types';
-import { t } from '../../i18n/utils';
+import type { Lang } from '@/i18n/types';
+import { t } from '@/i18n/utils';
 import TechConstellation from './TechConstellation.tsx';
-import SectionHeader from '../shared/SectionHeader.astro';
+import SectionHeader from '@/components/shared/SectionHeader.astro';
 
 interface Props {
   lang: Lang;

--- a/src/components/home/Testimonials.astro
+++ b/src/components/home/Testimonials.astro
@@ -1,8 +1,8 @@
 ---
-import { t } from '../../i18n/utils';
-import type { Lang } from '../../i18n/types';
+import { t } from '@/i18n/utils';
+import type { Lang } from '@/i18n/types';
 import TestimonialCard from './TestimonialCard.astro';
-import SectionHeader from '../shared/SectionHeader.astro';
+import SectionHeader from '@/components/shared/SectionHeader.astro';
 
 interface Props {
   lang: Lang;

--- a/src/components/home/WhatIDo.astro
+++ b/src/components/home/WhatIDo.astro
@@ -9,10 +9,10 @@
  * Uses IntersectionObserver + CSS custom properties (--stagger-delay) to
  * avoid JS animation loops. Respects prefers-reduced-motion.
  */
-import type { Lang } from '../../i18n/types';
-import { t } from '../../i18n/utils';
+import type { Lang } from '@/i18n/types';
+import { t } from '@/i18n/utils';
 import ServiceCard from './ServiceCard.astro';
-import SectionHeader from '../shared/SectionHeader.astro';
+import SectionHeader from '@/components/shared/SectionHeader.astro';
 
 interface Props {
   lang: Lang;

--- a/src/components/katas/KataCard.astro
+++ b/src/components/katas/KataCard.astro
@@ -1,8 +1,8 @@
 ---
-import Tag from '../shared/Tag.astro';
-import type { Kata } from '../../data/katas';
-import type { Lang } from '../../i18n/types';
-import { t } from '../../i18n/utils';
+import Tag from '@/components/shared/Tag.astro';
+import type { Kata } from '@/data/katas';
+import type { Lang } from '@/i18n/types';
+import { t } from '@/i18n/utils';
 
 interface Props {
   kata: Kata;

--- a/src/components/katas/KatasContent.astro
+++ b/src/components/katas/KatasContent.astro
@@ -1,11 +1,11 @@
 ---
 import KataCard from './KataCard.astro';
 import KatasScrollReveal from './KatasScrollReveal.astro';
-import DotField from '../shared/DotField.astro';
-import Button from '../shared/Button.astro';
-import { sortedKatas } from '../../data/katas';
-import type { Lang } from '../../i18n/types';
-import { getLocalePath, t } from '../../i18n/utils';
+import DotField from '@/components/shared/DotField.astro';
+import Button from '@/components/shared/Button.astro';
+import { sortedKatas } from '@/data/katas';
+import type { Lang } from '@/i18n/types';
+import { getLocalePath, t } from '@/i18n/utils';
 
 interface Props {
   lang: Lang;

--- a/src/components/legal/LegalPageLayout.astro
+++ b/src/components/legal/LegalPageLayout.astro
@@ -1,6 +1,6 @@
 ---
-import Layout from '../../layouts/Layout.astro';
-import type { Lang } from '../../i18n/types';
+import Layout from '@/layouts/Layout.astro';
+import type { Lang } from '@/i18n/types';
 
 interface Props {
   title: string;

--- a/src/components/nav/Nav.astro
+++ b/src/components/nav/Nav.astro
@@ -1,5 +1,5 @@
 ---
-import { getLangFromUrl, getLocalePath, t } from '../../i18n/utils';
+import { getLangFromUrl, getLocalePath, t } from '@/i18n/utils';
 
 interface Props {
   alternateUrl: string;

--- a/src/components/shared/DateDisplay.astro
+++ b/src/components/shared/DateDisplay.astro
@@ -15,7 +15,7 @@
  * Performance: Pure static HTML
  */
 
-import { formatDate, formatDateISO } from '../../lib/date';
+import { formatDate, formatDateISO } from '@/lib/date';
 
 interface Props {
   /**

--- a/src/data/cv.ts
+++ b/src/data/cv.ts
@@ -1,4 +1,4 @@
-import type { Lang } from '../i18n/types';
+import type { Lang } from '@/i18n/types';
 export type { Lang };
 
 export interface ContactInfo {

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -1,4 +1,4 @@
-import type { Lang } from '../i18n/types';
+import type { Lang } from '@/i18n/types';
 import { nav } from './messages/nav';
 import { katas } from './messages/katas';
 import { site } from './messages/site';

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -1,4 +1,4 @@
-import type { Lang } from '../i18n/types';
+import type { Lang } from '@/i18n/types';
 import { ui } from './ui';
 
 export function t(lang: Lang, key: string): string {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,12 +1,12 @@
 ---
 import { ClientRouter } from 'astro:transitions';
 import Analytics from '@vercel/analytics/astro';
-import GoogleAnalytics from '../components/analytics/GoogleAnalytics.astro';
-import CookieConsent from '../components/analytics/CookieConsent.astro';
-import Nav from "../components/nav/Nav.astro";
-import Footer from "../components/footer/Footer.astro";
-import { getLangFromUrl, getAlternateUrl, t } from '../i18n/utils';
-import type { Lang } from '../i18n/types';
+import GoogleAnalytics from '@/components/analytics/GoogleAnalytics.astro';
+import CookieConsent from '@/components/analytics/CookieConsent.astro';
+import Nav from "@/components/nav/Nav.astro";
+import Footer from "@/components/footer/Footer.astro";
+import { getLangFromUrl, getAlternateUrl, t } from '@/i18n/utils';
+import type { Lang } from '@/i18n/types';
 
 interface Props {
 	title: string;

--- a/src/lib/cv-to-json-resume.ts
+++ b/src/lib/cv-to-json-resume.ts
@@ -1,5 +1,5 @@
-import type { CvData } from '../data/cv';
-import type { Lang } from '../i18n/types';
+import type { CvData } from '@/data/cv';
+import type { Lang } from '@/i18n/types';
 
 interface JsonResumeBasics {
   name: string;

--- a/src/lib/schema-org.ts
+++ b/src/lib/schema-org.ts
@@ -1,5 +1,5 @@
-import type { Lang } from '../i18n/types';
-import { sortedKatas } from '../data/katas';
+import type { Lang } from '@/i18n/types';
+import { sortedKatas } from '@/data/katas';
 
 export function buildKatasCollectionSchema(
   lang: Lang,

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,6 +1,6 @@
 ---
-import Layout from '../layouts/Layout.astro';
-import { t } from '../i18n/utils';
+import Layout from '@/layouts/Layout.astro';
+import { t } from '@/i18n/utils';
 
 const requestedPath = Astro.url.pathname;
 ---

--- a/src/pages/aviso-legal.astro
+++ b/src/pages/aviso-legal.astro
@@ -1,5 +1,5 @@
 ---
-import LegalPageLayout from '../components/legal/LegalPageLayout.astro';
+import LegalPageLayout from '@/components/legal/LegalPageLayout.astro';
 ---
 
 <LegalPageLayout

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -31,16 +31,16 @@
 
 import { getCollection, type CollectionEntry, render } from 'astro:content';
 import { Image } from 'astro:assets';
-import Layout from '../../layouts/Layout.astro';
-import Tag from '../../components/shared/Tag.astro';
-import DateDisplay from '../../components/shared/DateDisplay.astro';
-import ReadingTime from '../../components/shared/ReadingTime.astro';
-import CodeBlockEnhancer from '../../components/blog/CodeBlockEnhancer.astro';
-import { calculateReadingTime } from '../../lib/blog';
-import { formatDate, formatDateISO } from '../../lib/date';
-import DotField from '../../components/shared/DotField.astro';
-import Button from '../../components/shared/Button.astro';
-import { t, getBlogSlugFromId } from '../../i18n/utils';
+import Layout from '@/layouts/Layout.astro';
+import Tag from '@/components/shared/Tag.astro';
+import DateDisplay from '@/components/shared/DateDisplay.astro';
+import ReadingTime from '@/components/shared/ReadingTime.astro';
+import CodeBlockEnhancer from '@/components/blog/CodeBlockEnhancer.astro';
+import { calculateReadingTime } from '@/lib/blog';
+import { formatDate, formatDateISO } from '@/lib/date';
+import DotField from '@/components/shared/DotField.astro';
+import Button from '@/components/shared/Button.astro';
+import { t, getBlogSlugFromId } from '@/i18n/utils';
 
 const lang = 'es';
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,4 +1,4 @@
 ---
-import BlogContent from '../../components/blog/BlogContent.astro';
+import BlogContent from '@/components/blog/BlogContent.astro';
 ---
 <BlogContent lang="es" />

--- a/src/pages/cookies.astro
+++ b/src/pages/cookies.astro
@@ -1,5 +1,5 @@
 ---
-import LegalPageLayout from '../components/legal/LegalPageLayout.astro';
+import LegalPageLayout from '@/components/legal/LegalPageLayout.astro';
 ---
 
 <LegalPageLayout

--- a/src/pages/cv/index.astro
+++ b/src/pages/cv/index.astro
@@ -1,4 +1,4 @@
 ---
-import CvContent from '../../components/cv/CvContent.astro';
+import CvContent from '@/components/cv/CvContent.astro';
 ---
 <CvContent lang="es" />

--- a/src/pages/cv/print.astro
+++ b/src/pages/cv/print.astro
@@ -1,6 +1,6 @@
 ---
-import CvPrintLayout from '../../components/cv/CvPrintLayout.astro';
-import { getCvData } from '../../data/cv';
+import CvPrintLayout from '@/components/cv/CvPrintLayout.astro';
+import { getCvData } from '@/data/cv';
 
 const data = getCvData('es');
 ---

--- a/src/pages/cv/resume.json.ts
+++ b/src/pages/cv/resume.json.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
-import { getCvData } from '../../data/cv';
-import { cvDataToJsonResume } from '../../lib/cv-to-json-resume';
+import { getCvData } from '@/data/cv';
+import { cvDataToJsonResume } from '@/lib/cv-to-json-resume';
 
 export const GET: APIRoute = () => {
   const data = getCvData('es');

--- a/src/pages/en/blog/[...slug].astro
+++ b/src/pages/en/blog/[...slug].astro
@@ -1,16 +1,16 @@
 ---
 import { getCollection, type CollectionEntry, render } from 'astro:content';
 import { Image } from 'astro:assets';
-import Layout from '../../../layouts/Layout.astro';
-import Tag from '../../../components/shared/Tag.astro';
-import DateDisplay from '../../../components/shared/DateDisplay.astro';
-import ReadingTime from '../../../components/shared/ReadingTime.astro';
-import CodeBlockEnhancer from '../../../components/blog/CodeBlockEnhancer.astro';
-import { calculateReadingTime } from '../../../lib/blog';
-import { formatDate, formatDateISO } from '../../../lib/date';
-import DotField from '../../../components/shared/DotField.astro';
-import Button from '../../../components/shared/Button.astro';
-import { t, getBlogSlugFromId } from '../../../i18n/utils';
+import Layout from '@/layouts/Layout.astro';
+import Tag from '@/components/shared/Tag.astro';
+import DateDisplay from '@/components/shared/DateDisplay.astro';
+import ReadingTime from '@/components/shared/ReadingTime.astro';
+import CodeBlockEnhancer from '@/components/blog/CodeBlockEnhancer.astro';
+import { calculateReadingTime } from '@/lib/blog';
+import { formatDate, formatDateISO } from '@/lib/date';
+import DotField from '@/components/shared/DotField.astro';
+import Button from '@/components/shared/Button.astro';
+import { t, getBlogSlugFromId } from '@/i18n/utils';
 
 const lang = 'en';
 

--- a/src/pages/en/blog/index.astro
+++ b/src/pages/en/blog/index.astro
@@ -1,4 +1,4 @@
 ---
-import BlogContent from '../../../components/blog/BlogContent.astro';
+import BlogContent from '@/components/blog/BlogContent.astro';
 ---
 <BlogContent lang="en" />

--- a/src/pages/en/cookies.astro
+++ b/src/pages/en/cookies.astro
@@ -1,5 +1,5 @@
 ---
-import LegalPageLayout from '../../components/legal/LegalPageLayout.astro';
+import LegalPageLayout from '@/components/legal/LegalPageLayout.astro';
 ---
 
 <LegalPageLayout

--- a/src/pages/en/cv/index.astro
+++ b/src/pages/en/cv/index.astro
@@ -1,4 +1,4 @@
 ---
-import CvContent from '../../../components/cv/CvContent.astro';
+import CvContent from '@/components/cv/CvContent.astro';
 ---
 <CvContent lang="en" />

--- a/src/pages/en/cv/print.astro
+++ b/src/pages/en/cv/print.astro
@@ -1,6 +1,6 @@
 ---
-import CvPrintLayout from '../../../components/cv/CvPrintLayout.astro';
-import { getCvData } from '../../../data/cv';
+import CvPrintLayout from '@/components/cv/CvPrintLayout.astro';
+import { getCvData } from '@/data/cv';
 
 const data = getCvData('en');
 ---

--- a/src/pages/en/cv/resume.json.ts
+++ b/src/pages/en/cv/resume.json.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
-import { getCvData } from '../../../data/cv';
-import { cvDataToJsonResume } from '../../../lib/cv-to-json-resume';
+import { getCvData } from '@/data/cv';
+import { cvDataToJsonResume } from '@/lib/cv-to-json-resume';
 
 export const GET: APIRoute = () => {
   const data = getCvData('en');

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1,6 +1,6 @@
 ---
-import Layout from '../../layouts/Layout.astro';
-import HomeContent from '../../components/home/HomeContent.astro';
+import Layout from '@/layouts/Layout.astro';
+import HomeContent from '@/components/home/HomeContent.astro';
 
 const personSchema = {
     '@context': 'https://schema.org',

--- a/src/pages/en/katas/index.astro
+++ b/src/pages/en/katas/index.astro
@@ -1,8 +1,8 @@
 ---
-import Layout from '../../../layouts/Layout.astro';
-import KatasContent from '../../../components/katas/KatasContent.astro';
-import { buildKatasCollectionSchema } from '../../../lib/schema-org';
-import { t } from '../../../i18n/utils';
+import Layout from '@/layouts/Layout.astro';
+import KatasContent from '@/components/katas/KatasContent.astro';
+import { buildKatasCollectionSchema } from '@/lib/schema-org';
+import { t } from '@/i18n/utils';
 
 const lang = 'en';
 const metaTitle = t(lang, 'katas.meta.title');

--- a/src/pages/en/legal-notice.astro
+++ b/src/pages/en/legal-notice.astro
@@ -1,5 +1,5 @@
 ---
-import LegalPageLayout from '../../components/legal/LegalPageLayout.astro';
+import LegalPageLayout from '@/components/legal/LegalPageLayout.astro';
 ---
 
 <LegalPageLayout

--- a/src/pages/en/portfolio/aitorevi-dev.astro
+++ b/src/pages/en/portfolio/aitorevi-dev.astro
@@ -1,4 +1,4 @@
 ---
-import SelfContent from '../../../components/case-study/SelfContent.astro';
+import SelfContent from '@/components/case-study/SelfContent.astro';
 ---
 <SelfContent lang="en" />

--- a/src/pages/en/portfolio/ims.astro
+++ b/src/pages/en/portfolio/ims.astro
@@ -1,6 +1,6 @@
 ---
-import Layout from '../../../layouts/Layout.astro';
-import { t } from '../../../i18n/utils';
+import Layout from '@/layouts/Layout.astro';
+import { t } from '@/i18n/utils';
 
 const lang = 'en';
 

--- a/src/pages/en/privacy.astro
+++ b/src/pages/en/privacy.astro
@@ -1,5 +1,5 @@
 ---
-import LegalPageLayout from '../../components/legal/LegalPageLayout.astro';
+import LegalPageLayout from '@/components/legal/LegalPageLayout.astro';
 ---
 
 <LegalPageLayout

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
-import Layout from '../layouts/Layout.astro';
-import HomeContent from '../components/home/HomeContent.astro';
+import Layout from '@/layouts/Layout.astro';
+import HomeContent from '@/components/home/HomeContent.astro';
 
 const personSchema = {
     '@context': 'https://schema.org',

--- a/src/pages/katas/index.astro
+++ b/src/pages/katas/index.astro
@@ -1,8 +1,8 @@
 ---
-import Layout from '../../layouts/Layout.astro';
-import KatasContent from '../../components/katas/KatasContent.astro';
-import { buildKatasCollectionSchema } from '../../lib/schema-org';
-import { t } from '../../i18n/utils';
+import Layout from '@/layouts/Layout.astro';
+import KatasContent from '@/components/katas/KatasContent.astro';
+import { buildKatasCollectionSchema } from '@/lib/schema-org';
+import { t } from '@/i18n/utils';
 
 const lang = 'es';
 const metaTitle = t(lang, 'katas.meta.title');

--- a/src/pages/portfolio/aitorevi-dev.astro
+++ b/src/pages/portfolio/aitorevi-dev.astro
@@ -1,4 +1,4 @@
 ---
-import SelfContent from '../../components/case-study/SelfContent.astro';
+import SelfContent from '@/components/case-study/SelfContent.astro';
 ---
 <SelfContent lang="es" />

--- a/src/pages/portfolio/ims.astro
+++ b/src/pages/portfolio/ims.astro
@@ -1,5 +1,5 @@
 ---
-import ImsContent from '../../components/case-study/ImsContent.astro';
+import ImsContent from '@/components/case-study/ImsContent.astro';
 ---
 
 <ImsContent />

--- a/src/pages/privacidad.astro
+++ b/src/pages/privacidad.astro
@@ -1,5 +1,5 @@
 ---
-import LegalPageLayout from '../components/legal/LegalPageLayout.astro';
+import LegalPageLayout from '@/components/legal/LegalPageLayout.astro';
 ---
 
 <LegalPageLayout

--- a/tests/unit/api/contact.test.ts
+++ b/tests/unit/api/contact.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { escapeHtml, buildConfirmationHtml, POST } from '../../../src/pages/api/contact';
+import { escapeHtml, buildConfirmationHtml, POST } from '@/pages/api/contact';
 
 // ---------------------------------------------------------------------------
 // escapeHtml

--- a/tests/unit/components/Button.test.ts
+++ b/tests/unit/components/Button.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildButtonClasses, resolveButtonProps } from '../../../src/components/shared/buttonStyles';
+import { buildButtonClasses, resolveButtonProps } from '@/components/shared/buttonStyles';
 
 describe('buildButtonClasses', () => {
   const BASE_TOKENS = [

--- a/tests/unit/components/GlassCard.test.ts
+++ b/tests/unit/components/GlassCard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { staggerDelay } from '../../../src/components/shared/glassCardStyles';
+import { staggerDelay } from '@/components/shared/glassCardStyles';
 
 describe('staggerDelay', () => {
   it('returns 0ms for the first item', () => {

--- a/tests/unit/components/ScoreBadge.test.ts
+++ b/tests/unit/components/ScoreBadge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { scoreTone } from '../../../src/components/case-study/scoreBadgeStyles';
+import { scoreTone } from '@/components/case-study/scoreBadgeStyles';
 
 describe('scoreTone', () => {
   describe('high tier (≥90)', () => {

--- a/tests/unit/data/cv.test.ts
+++ b/tests/unit/data/cv.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { cvES, cvEN, getCvData, getPdfPath, getJsonPath, getAlternateLangUrl } from '../../../src/data/cv';
+import { cvES, cvEN, getCvData, getPdfPath, getJsonPath, getAlternateLangUrl } from '@/data/cv';
 
 describe('getCvData', () => {
   it('returns cvES for lang "es"', () => {

--- a/tests/unit/data/katas.test.ts
+++ b/tests/unit/data/katas.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { katas, sortedKatas } from '../../../src/data/katas';
-import { buildKatasCollectionSchema } from '../../../src/lib/schema-org';
+import { katas, sortedKatas } from '@/data/katas';
+import { buildKatasCollectionSchema } from '@/lib/schema-org';
 
 describe('katas data', () => {
   it('has at least one kata', () => {

--- a/tests/unit/i18n/ui.test.ts
+++ b/tests/unit/i18n/ui.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { ui } from '../../../src/i18n/ui';
+import { ui } from '@/i18n/ui';
 
 describe('i18n dictionary consistency', () => {
   const esKeys = Object.keys(ui.es);

--- a/tests/unit/i18n/utils.test.ts
+++ b/tests/unit/i18n/utils.test.ts
@@ -6,7 +6,7 @@ import {
   getBlogSlugFromId,
   getBlogLangFromId,
   getLocalePath,
-} from '../../../src/i18n/utils';
+} from '@/i18n/utils';
 
 describe('t — translation lookup', () => {
   it('returns the translation for a known key in Spanish', () => {

--- a/tests/unit/lib/blog.test.ts
+++ b/tests/unit/lib/blog.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calculateReadingTime, sortPostsByDate, filterDrafts } from '../../../src/lib/blog';
+import { calculateReadingTime, sortPostsByDate, filterDrafts } from '@/lib/blog';
 
 describe('calculateReadingTime', () => {
   it('returns minimum 1 minute for empty content', () => {

--- a/tests/unit/lib/cv-to-json-resume.test.ts
+++ b/tests/unit/lib/cv-to-json-resume.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { cvDataToJsonResume } from '../../../src/lib/cv-to-json-resume';
-import { cvES, cvEN } from '../../../src/data/cv';
+import { cvDataToJsonResume } from '@/lib/cv-to-json-resume';
+import { cvES, cvEN } from '@/data/cv';
 
 describe('cvDataToJsonResume — structure', () => {
   it('includes the JSON Resume schema URL', () => {

--- a/tests/unit/lib/date.test.ts
+++ b/tests/unit/lib/date.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatDate, formatDateISO, getRelativeTime } from '../../../src/lib/date';
+import { formatDate, formatDateISO, getRelativeTime } from '@/lib/date';
 
 describe('formatDate', () => {
   it('formats a Date object in en-US', () => {

--- a/tests/unit/lib/strings.test.ts
+++ b/tests/unit/lib/strings.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { truncate, slugify } from '../../../src/lib/strings';
+import { truncate, slugify } from '@/lib/strings';
 
 describe('truncate', () => {
   it('returns text unchanged if shorter than maxLength', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "jsxImportSource": "react"
+    "jsxImportSource": "react",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": [
     "src/**/*"

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': resolve('./src'),
+    },
+  },
   define: {
     'import.meta.env.PROD': false,
     'import.meta.env.DEV': true,


### PR DESCRIPTION
## Summary

- Adds `@/*` → `src/*` path alias to `tsconfig.json`
- Adds matching `resolve.alias` to `vitest.config.js` (Vitest does not auto-read tsconfig paths)
- Rewrites all 180 cross-directory `../../` imports to `@/` form across `src/` and `tests/`
- Same-folder `./foo` imports left unchanged

## Test plan

- [x] `npx astro check` → 0 errors
- [x] `npm run test:unit` → 160 tests passing
- [x] Build green on CI

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)