### PR TITLE
fix(security): strip x-astro-path header, mitigates GHSA-mr6q-rp88-fx84, closes #113

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -65,6 +65,11 @@ const KEYSTATIC_SAVE_FEEDBACK_SCRIPT = `
 `;
 
 export const onRequest = defineMiddleware(async (context, next) => {
+  // GHSA-mr6q-rp88-fx84 — strip the header that @astrojs/vercel uses for
+  // path-override before the adapter can read it.
+  context.request.headers.delete('x-astro-path');
+  context.request.headers.delete('x_astro_path');
+
   const response = await next();
 
   if (!context.url.pathname.startsWith('/keystatic')) {


### PR DESCRIPTION
## Summary

`@astrojs/vercel@9.x` is vulnerable to GHSA-mr6q-rp88-fx84: the `x-astro-path` / `x_astro_path` request header can override path resolution in the Vercel adapter. The upstream fix requires upgrading to `@astrojs/vercel@10.x` which in turn requires Astro 6 — a major version bump outside the scope of this fix.

**Mitigation**: strip both headers in `src/middleware.ts` before the adapter reads them. Three lines, zero dependencies, no breaking changes.

Actual blast radius in this project was low (single serverless route: `/api/contact`, no auth-protected Astro routes), but the mitigation is trivial so there is no reason to leave it open.

## Test plan

- [x] `npx astro check` → 0 errors
- [x] `npm run test:unit` → 160 tests passing
- [ ] Build green on CI
- [ ] Verify in Vercel preview: `curl -H 'x-astro-path: /admin' https://preview-url/api/contact` returns normal contact response, not a path override

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)