### PR TITLE
fix(ci): pin actions to SHA and minimum permissions, closes #116 #117

### DIFF
--- a/.github/workflows/check-kata-links.yml
+++ b/.github/workflows/check-kata-links.yml
@@ -10,12 +10,15 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
       - run: node scripts/check-kata-links.mjs

--- a/.github/workflows/keep-alive-upstash.yml
+++ b/.github/workflows/keep-alive-upstash.yml
@@ -5,6 +5,8 @@ on:
     - cron: '0 9 * * 1,4' # Mondays and Thursdays at 09:00 UTC
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   ping:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,13 +5,16 @@ on:
     branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -40,7 +43,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report
           path: playwright-report/


### PR DESCRIPTION
## Summary

- **SHA pinning** (#116): all third-party actions now reference immutable commit SHAs. A compromised `v4` floating tag cannot inject code into CI.
- **Minimum permissions** (#117): each workflow declares only what it needs — `contents: read` for workflows that checkout, `permissions: {}` for keep-alive (no repo access).
- Bumped `check-kata-links` to Node 22 for consistency with `test.yml`.

| Workflow | Before | After |
|---|---|---|
| `test.yml` | implicit write-all | `contents: read` |
| `check-kata-links.yml` | implicit write-all | `contents: read` |
| `keep-alive-upstash.yml` | implicit write-all | `{}` (none) |

## Test plan

- [x] CI passes on this PR
- [x] `keep-alive-upstash` still pings Redis successfully (can trigger via workflow_dispatch)

Closes #116, #117