### PR TITLE
fix(security): extract first IP from x-forwarded-for, closes #118

### DIFF
--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -172,7 +172,8 @@ export const POST: APIRoute = async ({ request }) => {
   const ratelimiter = getRatelimiter();
   if (ratelimiter) {
     try {
-      const ip = request.headers.get('x-forwarded-for') ?? 'anonymous';
+      const forwarded = request.headers.get('x-forwarded-for') ?? '';
+      const ip = forwarded.split(',')[0].trim() || 'anonymous';
       const { success } = await ratelimiter.limit(ip);
       if (!success) {
         return new Response(JSON.stringify({ error: 'too_many_requests' }), {


### PR DESCRIPTION
## Summary

`x-forwarded-for` can contain multiple IPs (`client, proxy1, proxy2`). Using the full header as the rate limit key meant an attacker could bypass the 5 req/h limit by sending a different header value on each request.

Fix: take only `split(',')[0].trim()` — the leftmost IP, which is the original client IP in Vercel's infrastructure.

## Test plan

- [x] `npm run test:unit` → 160 passing
- [x] CI green

Closes #118