### PR TITLE
fix(security): escape </script> in JSON-LD, closes #122

### DIFF
--- a/src/components/blog/BlogContent.astro
+++ b/src/components/blog/BlogContent.astro
@@ -7,6 +7,7 @@ import Button from '@/components/shared/Button.astro';
 import { sortPostsByDate, filterDrafts } from '@/lib/blog';
 import { t, getBlogSlugFromId, getLocalePath } from '@/i18n/utils';
 import type { Lang } from '@/i18n/types';
+import { safeJsonLd } from '@/lib/schema-org';
 
 interface Props {
   lang: Lang;
@@ -50,7 +51,7 @@ const regularItemClass = regularPosts.length === 1
     <meta property="og:description" content={t(lang, 'blog.description')} />
     <link rel="canonical" href={new URL(blogPath, Astro.site).href} />
 
-    <script is:inline type="application/ld+json" set:html={JSON.stringify({
+    <script is:inline type="application/ld+json" set:html={safeJsonLd({
       "@context": "https://schema.org",
       "@type": "Blog",
       "name": "aitorevi Blog",

--- a/src/lib/schema-org.ts
+++ b/src/lib/schema-org.ts
@@ -1,6 +1,10 @@
 import type { Lang } from '@/i18n/types';
 import { sortedKatas } from '@/data/katas';
 
+export function safeJsonLd(obj: unknown): string {
+  return JSON.stringify(obj).replace(/<\//g, '<\\/');
+}
+
 export function buildKatasCollectionSchema(
   lang: Lang,
   canonicalUrl: string,

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -41,6 +41,7 @@ import { formatDate, formatDateISO } from '@/lib/date';
 import DotField from '@/components/shared/DotField.astro';
 import Button from '@/components/shared/Button.astro';
 import { t, getBlogSlugFromId } from '@/i18n/utils';
+import { safeJsonLd } from '@/lib/schema-org';
 
 const lang = 'es';
 
@@ -127,7 +128,7 @@ const coverImageAbsolute = toAbsoluteUrl(coverImageUrl);
     <link rel="canonical" href={canonicalUrl} />
 
     <!-- Schema.org JSON-LD -->
-    <script is:inline type="application/ld+json" set:html={JSON.stringify({
+    <script is:inline type="application/ld+json" set:html={safeJsonLd({
       "@context": "https://schema.org",
       "@type": "BlogPosting",
       "headline": data.title,

--- a/src/pages/en/blog/[...slug].astro
+++ b/src/pages/en/blog/[...slug].astro
@@ -11,6 +11,7 @@ import { formatDate, formatDateISO } from '@/lib/date';
 import DotField from '@/components/shared/DotField.astro';
 import Button from '@/components/shared/Button.astro';
 import { t, getBlogSlugFromId } from '@/i18n/utils';
+import { safeJsonLd } from '@/lib/schema-org';
 
 const lang = 'en';
 
@@ -81,7 +82,7 @@ const coverImageAbsolute = toAbsoluteUrl(coverImageUrl);
     <meta name="twitter:description" content={data.description} />
     <meta name="twitter:image" content={ogImageAbsolute} />
     <link rel="canonical" href={canonicalUrl} />
-    <script is:inline type="application/ld+json" set:html={JSON.stringify({
+    <script is:inline type="application/ld+json" set:html={safeJsonLd({
       "@context": "https://schema.org",
       "@type": "BlogPosting",
       "headline": data.title,

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '@/layouts/Layout.astro';
 import HomeContent from '@/components/home/HomeContent.astro';
+import { safeJsonLd } from '@/lib/schema-org';
 
 const personSchema = {
     '@context': 'https://schema.org',
@@ -24,6 +25,6 @@ const personSchema = {
 <Layout title="aitorevi.dev">
     <link slot="head" rel="preload" as="image" href="/avatar-light.webp" fetchpriority="high" media="(prefers-color-scheme: light)" />
     <link slot="head" rel="preload" as="image" href="/avatar.webp" fetchpriority="high" media="(prefers-color-scheme: dark)" />
-    <script slot="head" is:inline type="application/ld+json" set:html={JSON.stringify(personSchema)}></script>
+    <script slot="head" is:inline type="application/ld+json" set:html={safeJsonLd(personSchema)}></script>
     <HomeContent lang="en" />
 </Layout>

--- a/src/pages/en/katas/index.astro
+++ b/src/pages/en/katas/index.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '@/layouts/Layout.astro';
 import KatasContent from '@/components/katas/KatasContent.astro';
-import { buildKatasCollectionSchema } from '@/lib/schema-org';
+import { buildKatasCollectionSchema, safeJsonLd } from '@/lib/schema-org';
 import { t } from '@/i18n/utils';
 
 const lang = 'en';
@@ -12,6 +12,6 @@ const schema = buildKatasCollectionSchema(lang, canonicalUrl, metaTitle, metaDes
 ---
 
 <Layout title={metaTitle} description={metaDescription} lang={lang} ogImage="/og/og-katas.png" variant="dark-radial">
-  <script slot="head" is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
+  <script slot="head" is:inline type="application/ld+json" set:html={safeJsonLd(schema)} />
   <KatasContent lang={lang} />
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '@/layouts/Layout.astro';
 import HomeContent from '@/components/home/HomeContent.astro';
+import { safeJsonLd } from '@/lib/schema-org';
 
 const personSchema = {
     '@context': 'https://schema.org',
@@ -24,6 +25,6 @@ const personSchema = {
 <Layout title="aitorevi.dev">
     <link slot="head" rel="preload" as="image" href="/avatar-light.webp" fetchpriority="high" media="(prefers-color-scheme: light)" />
     <link slot="head" rel="preload" as="image" href="/avatar.webp" fetchpriority="high" media="(prefers-color-scheme: dark)" />
-    <script slot="head" is:inline type="application/ld+json" set:html={JSON.stringify(personSchema)}></script>
+    <script slot="head" is:inline type="application/ld+json" set:html={safeJsonLd(personSchema)}></script>
     <HomeContent lang="es" />
 </Layout>

--- a/src/pages/katas/index.astro
+++ b/src/pages/katas/index.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '@/layouts/Layout.astro';
 import KatasContent from '@/components/katas/KatasContent.astro';
-import { buildKatasCollectionSchema } from '@/lib/schema-org';
+import { buildKatasCollectionSchema, safeJsonLd } from '@/lib/schema-org';
 import { t } from '@/i18n/utils';
 
 const lang = 'es';
@@ -12,6 +12,6 @@ const schema = buildKatasCollectionSchema(lang, canonicalUrl, metaTitle, metaDes
 ---
 
 <Layout title={metaTitle} description={metaDescription} lang={lang} ogImage="/og/og-katas.png" variant="dark-radial">
-  <script slot="head" is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
+  <script slot="head" is:inline type="application/ld+json" set:html={safeJsonLd(schema)} />
   <KatasContent lang={lang} />
 </Layout>


### PR DESCRIPTION
## Summary

Added `safeJsonLd(obj)` helper to `src/lib/schema-org.ts` that replaces `</` → `<\/` in the serialized JSON before injecting it into `<script type="application/ld+json">` blocks. This prevents a latent XSS where a post title/description containing `</script>` would break out of the script tag context.

Replaced all 7 occurrences of `set:html={JSON.stringify(...)}` with `set:html={safeJsonLd(...)}`.

## Test plan

- [x] `npm run test:unit` → 160 passing
- [x] `npm run build` green
- [x] CI green

Closes #122