### PR TITLE
fix(privacy): gate Vercel Analytics behind consent, closes #119

### DIFF
--- a/src/components/analytics/CookieConsent.astro
+++ b/src/components/analytics/CookieConsent.astro
@@ -119,6 +119,11 @@ const copy = isES
           // trackPageView in GoogleAnalytics.astro gated on consent, so the
           // initial astro:page-load hit was suppressed.
           trackPageViewAfterConsent();
+          // Same for Vercel Analytics: beforeSend blocked the initial hit,
+          // so fire it manually now that consent is granted.
+          if (window.va) {
+            window.va('pageview', { path: window.location.pathname });
+          }
           banner.hidden = true;
         });
       });

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -95,6 +95,14 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `https://www.aitorevi.
 					event.preventDefault();
 				}
 			});
+			// Gate Vercel Analytics behind consent. The Analytics component
+			// reads window.webAnalyticsBeforeSend before sending any event;
+			// returning null cancels it. Must be set before the custom element
+			// mounts (end of body), which is why it lives here in the head.
+			window.webAnalyticsBeforeSend = function(event) {
+				var m = document.cookie.match(/(?:^|; )aitorevi_consent=(granted|denied)/);
+				return m && m[1] === 'granted' ? event : null;
+			};
 		</script>
 		<ClientRouter />
 		{import.meta.env.PUBLIC_GSC_VERIFICATION && (


### PR DESCRIPTION
## Summary

Vercel Analytics was sending a pageview beacon on every page load before the user had granted consent, violating ePrivacy/RGPD.

**Fix**: set `window.webAnalyticsBeforeSend` in the inline `<head>` script (runs before the Analytics custom element mounts at end of body). The hook returns `null` when `aitorevi_consent` is not `granted`, cancelling all events. When the user accepts via the banner, `window.va('pageview', ...)` fires the suppressed hit — matching the existing GA4 behaviour.

## Behaviour

| State | GA4 | Vercel Analytics |
|---|---|---|
| No consent yet | ✅ blocked | ✅ blocked (was ❌) |
| Consent granted | ✅ fires | ✅ fires |
| Consent denied | ✅ blocked | ✅ blocked |

## Test plan

- [x] `npm run test:unit` → 160 passing
- [x] `npm run build` green
- [x] Preview: open Network tab, visit site without consent → no request to `/_vercel/insights/view`
- [x] Preview: accept consent → `/_vercel/insights/view` fires once

Closes #119