### PR TITLE
fix(csp): allow Keystatic production dependencies

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -10,7 +10,7 @@
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' data: https://www.googletagmanager.com https://vercel.live; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com https://vercel.live wss://ws-us3.pusher.com https://sockjs-us3.pusher.com; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' https://vercel.live https://assets.vercel.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; frame-src https://vercel.live"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' data: https://www.googletagmanager.com https://vercel.live; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com https://vercel.live wss://ws-us3.pusher.com https://sockjs-us3.pusher.com https://api.github.com; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com https://vercel.live https://assets.vercel.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; frame-src https://vercel.live"
         },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" }
       ]


### PR DESCRIPTION
## Summary

Keystatic admin UI was rendering a black screen after GitHub OAuth login in production. Two CSP violations blocked it:

1. `fonts.googleapis.com` — Keystatic loads the Inter font; blocked by `style-src`
2. `api.github.com/graphql` — Keystatic commits content via GitHub GraphQL API; blocked by `connect-src`

## Changes

- `connect-src` → add `https://api.github.com`
- `style-src` → add `https://fonts.googleapis.com`
- `font-src` → add `https://fonts.gstatic.com` (where Google Fonts serves the actual font files)

## Test plan

- [ ] Deploy to Vercel and access `/keystatic`
- [ ] Log in with GitHub — UI renders correctly (no black screen)
- [ ] Edit a post and save — commit appears in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)