### PR TITLE
fix(csp): add raw.githubusercontent.com for Keystatic editor

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -10,7 +10,7 @@
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' data: https://www.googletagmanager.com https://vercel.live; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com https://vercel.live wss://ws-us3.pusher.com https://sockjs-us3.pusher.com https://api.github.com; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com https://vercel.live https://assets.vercel.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; frame-src https://vercel.live"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' data: https://www.googletagmanager.com https://vercel.live; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com https://vercel.live wss://ws-us3.pusher.com https://sockjs-us3.pusher.com https://api.github.com https://raw.githubusercontent.com; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com https://vercel.live https://assets.vercel.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; frame-src https://vercel.live"
         },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" }
       ]


### PR DESCRIPTION
## Summary

Follow-up to #147. Keystatic editor in GitHub mode fetches post content and repo assets directly from `raw.githubusercontent.com` — this was being blocked by `connect-src`.

**Error in production:**
```
Fetch API cannot load https://raw.githubusercontent.com/aitorevi/aitorevi-blog/.../src/content/blog/es/dependency-inversion.md
Refused to connect because it violates the document's Content Security Policy.
```

## Change

`connect-src` → add `https://raw.githubusercontent.com`

## Test plan

- [ ] Deploy and open `/keystatic`
- [ ] Edit a blog post — content loads without CSP errors
- [ ] Save — commit appears in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)