### PR TITLE
feat(blog): cinematic post page

### DIFF
--- a/src/components/blog/BlogContent.astro
+++ b/src/components/blog/BlogContent.astro
@@ -265,6 +265,7 @@ const outroTitle = lang === 'es'
         prevUrl={prevUrl}
         nextUrl={nextUrl}
         lang={lang}
+        basePath={blogPath}
       />
     )}
 

--- a/src/components/blog/BlogContent.astro
+++ b/src/components/blog/BlogContent.astro
@@ -15,12 +15,14 @@ interface Props {
   posts: CollectionEntry<'blog'>[];
   currentPage: number;
   totalPages: number;
+  totalPosts: number;
+  pageOffset: number;
   prevUrl?: string;
   nextUrl?: string;
   alternateUrl: string;
 }
 
-const { lang, posts, currentPage, totalPages, prevUrl, nextUrl, alternateUrl } = Astro.props;
+const { lang, posts, currentPage, totalPages, totalPosts, pageOffset, prevUrl, nextUrl, alternateUrl } = Astro.props;
 const blogPath = lang === 'en' ? '/en/blog' : '/blog';
 
 const accentCycle = ['violet', 'blue', 'emerald', 'sky'] as const;
@@ -109,7 +111,7 @@ const outroTitle = lang === 'es'
       const postUrl = lang === 'en' ? `/en/blog/${slug}` : `/blog/${slug}`;
       const reading = calculateReadingTime(post.body || '', lang);
       const tags = post.data.tags.slice(0, 3);
-      const number = String(i + 1).padStart(2, '0');
+      const number = String(totalPosts - (pageOffset + i)).padStart(2, '0');
       return (
         <article
           class="cinematic-section relative px-6 py-12 md:py-16"

--- a/src/components/blog/BlogContent.astro
+++ b/src/components/blog/BlogContent.astro
@@ -44,11 +44,11 @@ const searchIndexJson = JSON.stringify(searchIndex).replace(/<\/script>/gi, '<\\
 
 const accentCycle = ['violet', 'blue', 'emerald', 'sky'] as const;
 type Accent = (typeof accentCycle)[number];
-const accentMap: Record<Accent, { text: string; bg: string; ring: string; glow: string }> = {
-  violet:  { text: 'text-accent-violet',  bg: 'bg-accent-violet',  ring: 'ring-accent-violet/40',  glow: 'from-accent-violet/30' },
-  blue:    { text: 'text-accent-blue',    bg: 'bg-accent-blue',    ring: 'ring-accent-blue/40',    glow: 'from-accent-blue/30' },
-  emerald: { text: 'text-emerald-400',    bg: 'bg-emerald-400',    ring: 'ring-emerald-400/40',    glow: 'from-emerald-400/25' },
-  sky:     { text: 'text-accent-sky',     bg: 'bg-accent-sky',     ring: 'ring-accent-sky/40',     glow: 'from-accent-sky/25' },
+const accentMap: Record<Accent, { text: string; bg: string; ring: string; glow: string; line: string }> = {
+  violet:  { text: 'text-accent-violet',  bg: 'bg-accent-violet',  ring: 'ring-accent-violet/40',  glow: 'from-accent-violet/30', line: 'via-accent-violet/25' },
+  blue:    { text: 'text-accent-blue',    bg: 'bg-accent-blue',    ring: 'ring-accent-blue/40',    glow: 'from-accent-blue/30',   line: 'via-accent-blue/25' },
+  emerald: { text: 'text-emerald-400',    bg: 'bg-emerald-400',    ring: 'ring-emerald-400/40',    glow: 'from-emerald-400/25',   line: 'via-emerald-400/20' },
+  sky:     { text: 'text-accent-sky',     bg: 'bg-accent-sky',     ring: 'ring-accent-sky/40',     glow: 'from-accent-sky/25',    line: 'via-accent-sky/20' },
 };
 
 const ctaLabel = lang === 'es' ? 'Leer artículo' : 'Read article';
@@ -125,8 +125,7 @@ const outroTitle = lang === 'es'
             data-cinematic-section
             aria-labelledby={`post-${slug}`}
           >
-            <div aria-hidden="true" class={`pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br ${accent.glow} via-transparent to-transparent opacity-30`}></div>
-            <div aria-hidden="true" class="pointer-events-none absolute inset-x-0 top-0 -z-10 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent"></div>
+            <div aria-hidden="true" class={`pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent ${accent.line} to-transparent`}></div>
 
             <div class="mx-auto grid w-full max-w-5xl grid-cols-1 items-center gap-8 md:grid-cols-12 md:gap-10 lg:gap-12">
               <div class={`md:col-span-6 lg:col-span-6 ${flip ? 'md:order-2' : ''}`} data-cinematic-meta>

--- a/src/components/blog/BlogContent.astro
+++ b/src/components/blog/BlogContent.astro
@@ -34,8 +34,8 @@ const ctaLabel = lang === 'es' ? 'Leer artículo' : 'Read article';
 const featuredLabel = lang === 'es' ? 'destacado' : 'featured';
 
 const outroTitle = lang === 'es'
-  ? `${publishedPosts.length} notas. De momento.`
-  : `${publishedPosts.length} notes. For now.`;
+  ? 'Cada artículo, un aprendizaje.'
+  : 'Every article, a lesson.';
 ---
 
 <Layout
@@ -107,27 +107,33 @@ const outroTitle = lang === 'es'
       const number = String(i + 1).padStart(2, '0');
       return (
         <article
-          class="cinematic-section relative flex min-h-screen items-center px-6 py-24 md:py-28"
+          class="cinematic-section relative px-6 py-12 md:py-16"
           data-cinematic-section
           aria-labelledby={`post-${slug}`}
         >
-          <!-- Per-section ambient glow -->
-          <div aria-hidden="true" class={`pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br ${accent.glow} via-transparent to-transparent opacity-70`}></div>
-          <div aria-hidden="true" class="pointer-events-none absolute inset-x-0 top-0 -z-10 h-px bg-gradient-to-r from-transparent via-white/20 to-transparent"></div>
+          <!-- Per-section ambient glow (subtle so the list doesn't feel saturated) -->
+          <div aria-hidden="true" class={`pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br ${accent.glow} via-transparent to-transparent opacity-30`}></div>
+          <div aria-hidden="true" class="pointer-events-none absolute inset-x-0 top-0 -z-10 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent"></div>
 
-          <div class="mx-auto grid w-full max-w-6xl grid-cols-1 gap-12 md:grid-cols-12 md:gap-12 lg:gap-16">
+          <div class="mx-auto grid w-full max-w-5xl grid-cols-1 items-center gap-8 md:grid-cols-12 md:gap-10 lg:gap-12">
             <!-- Meta -->
             <div
-              class={`md:col-span-5 lg:col-span-5 ${flip ? 'md:order-2' : ''}`}
+              class={`md:col-span-6 lg:col-span-6 ${flip ? 'md:order-2' : ''}`}
               data-cinematic-meta
             >
-              <div class="md:sticky md:top-32 space-y-7">
-                <div class="flex items-baseline gap-4">
-                  <span class={`font-display text-5xl font-black tracking-tighter ${accent.text} md:text-6xl`}>
+              <div class="space-y-4">
+                <div class="flex items-baseline gap-3">
+                  <span class={`font-display text-3xl font-black tracking-tighter ${accent.text} md:text-4xl`}>
                     {number}
                   </span>
+                  <span class="font-mono text-[10px] uppercase tracking-[0.25em] text-slate-500 dark:text-slate-400 normal-case tracking-normal text-xs">
+                    {formatDate(post.data.publishDate, lang === 'es' ? 'es-ES' : 'en-US')}
+                  </span>
+                  <span class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                    · {reading.minutes} {lang === 'es' ? 'min' : 'min'}
+                  </span>
                   {post.data.featured && (
-                    <span class={`inline-flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.25em] ${accent.text}`}>
+                    <span class={`inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.25em] ${accent.text}`}>
                       <span class={`h-1.5 w-1.5 rounded-full ${accent.bg} animate-pulse`}></span>
                       {featuredLabel}
                     </span>
@@ -136,31 +142,19 @@ const outroTitle = lang === 'es'
 
                 <h2
                   id={`post-${slug}`}
-                  class="font-display text-3xl font-black leading-tight tracking-tight text-ink-900 dark:text-slate-50 md:text-4xl lg:text-5xl"
+                  class="font-display text-2xl font-black leading-tight tracking-tight text-ink-900 dark:text-slate-50 md:text-3xl"
                 >
-                  <a href={postUrl} class="transition-colors hover:text-secondary focus:outline-none focus-visible:underline dark:hover:text-accent-blue">
+                  <a
+                    href={postUrl}
+                    class="transition-colors duration-200 hover:text-secondary focus:text-secondary focus:outline-none focus-visible:underline dark:hover:text-accent-violet dark:focus:text-accent-violet"
+                  >
                     {post.data.title}
                   </a>
                 </h2>
 
-                <p class="max-w-md text-sm leading-relaxed text-slate-700 dark:text-slate-300 md:text-base">
+                <p class="text-sm leading-relaxed text-slate-700 dark:text-slate-300 line-clamp-3">
                   {post.data.description}
                 </p>
-
-                <dl class="grid grid-cols-2 gap-x-6 gap-y-3 border-l border-white/10 pl-5 font-mono text-[11px] uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
-                  <div>
-                    <dt class="text-[9px]">{lang === 'es' ? 'Fecha' : 'Date'}</dt>
-                    <dd class="mt-1 text-slate-700 dark:text-slate-200 normal-case tracking-normal text-xs">
-                      {formatDate(post.data.publishDate, lang === 'es' ? 'es-ES' : 'en-US')}
-                    </dd>
-                  </div>
-                  <div>
-                    <dt class="text-[9px]">{lang === 'es' ? 'Lectura' : 'Reading'}</dt>
-                    <dd class={`mt-1 font-display text-2xl font-black ${accent.text} normal-case tracking-tight`}>
-                      {reading.minutes}<span class="ml-1 font-mono text-[10px] tracking-[0.18em] uppercase text-slate-500 dark:text-slate-400">{lang === 'es' ? 'min' : 'min'}</span>
-                    </dd>
-                  </div>
-                </dl>
 
                 {tags.length > 0 && (
                   <ul class="flex flex-wrap gap-2 list-none p-0" aria-label={t(lang, 'blog.tags')}>
@@ -172,10 +166,10 @@ const outroTitle = lang === 'es'
 
                 <a
                   href={postUrl}
-                  class={`group inline-flex items-center gap-3 font-mono text-xs uppercase tracking-[0.25em] ${accent.text} transition-colors hover:text-ink-900 dark:hover:text-white focus:outline-none focus-visible:underline`}
+                  class={`group inline-flex items-center gap-3 font-mono text-xs uppercase tracking-[0.25em] ${accent.text} focus:outline-none focus-visible:underline`}
                 >
                   <span>{ctaLabel}</span>
-                  <span class={`relative h-px w-12 ${accent.bg} transition-all duration-500 group-hover:w-20`}></span>
+                  <span class={`relative h-px w-10 ${accent.bg} transition-all duration-500 group-hover:w-16`}></span>
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     fill="none"
@@ -195,19 +189,19 @@ const outroTitle = lang === 'es'
 
             <!-- Visual -->
             <div
-              class={`md:col-span-7 lg:col-span-7 ${flip ? 'md:order-1' : ''}`}
+              class={`md:col-span-6 lg:col-span-6 ${flip ? 'md:order-1' : ''}`}
               data-cinematic-visual
             >
               <a
                 href={postUrl}
-                class={`cinematic-mock ${flip ? 'cinematic-mock--flip' : ''} block relative overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-br from-ink-800 to-ink-900 p-1 shadow-2xl ring-1 ${accent.ring} focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-blue`}
+                class={`cinematic-mock ${flip ? 'cinematic-mock--flip' : ''} block relative overflow-hidden rounded-xl border border-white/10 bg-gradient-to-br from-ink-800 to-ink-900 p-1 shadow-xl ring-1 ${accent.ring} focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-blue`}
                 aria-label={`${ctaLabel}: ${post.data.title}`}
               >
-                <div class="flex items-center gap-1.5 border-b border-white/5 bg-ink-800/95 px-4 py-2.5 backdrop-blur">
-                  <span class="h-2.5 w-2.5 rounded-full bg-red-400/70"></span>
-                  <span class="h-2.5 w-2.5 rounded-full bg-yellow-400/70"></span>
-                  <span class="h-2.5 w-2.5 rounded-full bg-green-400/70"></span>
-                  <span class="ml-4 font-mono text-[10px] text-slate-400 truncate">
+                <div class="flex items-center gap-1.5 border-b border-white/5 bg-ink-800/95 px-3 py-2 backdrop-blur">
+                  <span class="h-2 w-2 rounded-full bg-red-400/70"></span>
+                  <span class="h-2 w-2 rounded-full bg-yellow-400/70"></span>
+                  <span class="h-2 w-2 rounded-full bg-green-400/70"></span>
+                  <span class="ml-3 font-mono text-[9px] text-slate-400 truncate">
                     aitorevi.dev{postUrl}
                   </span>
                 </div>
@@ -224,16 +218,13 @@ const outroTitle = lang === 'es'
                     />
                   ) : (
                     <div class="flex h-full w-full items-center justify-center bg-gradient-to-br from-ink-800 to-ink-900">
-                      <span class="select-none font-display text-5xl font-black tracking-tight text-slate-50 md:text-6xl">
+                      <span class="select-none font-display text-4xl font-black tracking-tight text-slate-50">
                         aitorevi<span class={accent.text}>.</span>
                       </span>
                     </div>
                   )}
                 </div>
               </a>
-              <p class="mt-4 text-right font-mono text-[10px] uppercase tracking-[0.25em] text-slate-500">
-                {number} / {String(publishedPosts.length).padStart(2, '0')}
-              </p>
             </div>
           </div>
         </article>
@@ -269,6 +260,13 @@ const outroTitle = lang === 'es'
 </Layout>
 
 <style>
+  .line-clamp-3 {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
   .cinematic-section [data-cinematic-meta],
   .cinematic-section [data-cinematic-visual] {
     opacity: 0;

--- a/src/components/blog/BlogContent.astro
+++ b/src/components/blog/BlogContent.astro
@@ -109,7 +109,6 @@ const outroTitle = lang === 'es'
       const postUrl = lang === 'en' ? `/en/blog/${slug}` : `/blog/${slug}`;
       const reading = calculateReadingTime(post.body || '', lang);
       const tags = post.data.tags.slice(0, 3);
-      const number = String(i + 1).padStart(2, '0');
       return (
         <article
           class="cinematic-section relative px-6 py-12 md:py-16"
@@ -127,14 +126,11 @@ const outroTitle = lang === 'es'
             >
               <div class="space-y-4">
                 <div class="flex items-baseline gap-3">
-                  <span class={`font-display text-3xl font-black tracking-tighter ${accent.text} md:text-4xl`}>
-                    {number}
-                  </span>
                   <span class="font-mono text-[10px] uppercase tracking-[0.25em] text-slate-500 dark:text-slate-400 normal-case tracking-normal text-xs">
                     {formatDate(post.data.publishDate, lang === 'es' ? 'es-ES' : 'en-US')}
                   </span>
                   <span class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
-                    · {reading.minutes} {lang === 'es' ? 'min' : 'min'}
+                    · {reading.minutes} min
                   </span>
                   {post.data.featured && (
                     <span class={`inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.25em] ${accent.text}`}>

--- a/src/components/blog/BlogContent.astro
+++ b/src/components/blog/BlogContent.astro
@@ -1,9 +1,10 @@
 ---
-import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
 import Layout from '@/layouts/Layout.astro';
 import DotField from '@/components/shared/DotField.astro';
 import Tag from '@/components/shared/Tag.astro';
-import { sortPostsByDate, filterDrafts, calculateReadingTime } from '@/lib/blog';
+import BlogPagination from '@/components/blog/BlogPagination.astro';
+import { calculateReadingTime } from '@/lib/blog';
 import { formatDate } from '@/lib/date';
 import { t, getBlogSlugFromId } from '@/i18n/utils';
 import type { Lang } from '@/i18n/types';
@@ -11,15 +12,16 @@ import { safeJsonLd } from '@/lib/schema-org';
 
 interface Props {
   lang: Lang;
+  posts: CollectionEntry<'blog'>[];
+  currentPage: number;
+  totalPages: number;
+  prevUrl?: string;
+  nextUrl?: string;
+  alternateUrl: string;
 }
 
-const { lang } = Astro.props;
+const { lang, posts, currentPage, totalPages, prevUrl, nextUrl, alternateUrl } = Astro.props;
 const blogPath = lang === 'en' ? '/en/blog' : '/blog';
-
-const allPosts = await getCollection('blog');
-const publishedPosts = sortPostsByDate(filterDrafts(allPosts)).filter((post) =>
-  post.id.startsWith(`${lang}/`)
-);
 
 const accentCycle = ['violet', 'blue', 'emerald', 'sky'] as const;
 type Accent = (typeof accentCycle)[number];
@@ -42,11 +44,14 @@ const outroTitle = lang === 'es'
   title="Blog | aitorevi"
   description={t(lang, 'blog.description')}
   variant="dark-radial"
+  alternateUrl={alternateUrl}
 >
   <Fragment slot="head">
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Blog | aitorevi" />
     <meta property="og:description" content={t(lang, 'blog.description')} />
+    {prevUrl && <link rel="prev" href={new URL(prevUrl, Astro.site).href} />}
+    {nextUrl && <link rel="next" href={new URL(nextUrl, Astro.site).href} />}
 
     <script is:inline type="application/ld+json" set:html={safeJsonLd({
       "@context": "https://schema.org",
@@ -55,7 +60,7 @@ const outroTitle = lang === 'es'
       "description": t(lang, 'blog.description'),
       "url": new URL(blogPath, Astro.site).href,
       "author": { "@type": "Person", "name": "aitorevi" },
-      "blogPost": publishedPosts.slice(0, 10).map(post => ({
+      "blogPost": posts.slice(0, 10).map(post => ({
         "@type": "BlogPosting",
         "headline": post.data.title,
         "description": post.data.description,
@@ -97,7 +102,7 @@ const outroTitle = lang === 'es'
     </header>
 
     <!-- Posts as cinematic sections -->
-    {publishedPosts.length > 0 && publishedPosts.map((post, i) => {
+    {posts.length > 0 && posts.map((post, i) => {
       const accent = accentMap[accentCycle[i % accentCycle.length]];
       const flip = i % 2 === 1;
       const slug = getBlogSlugFromId(post.id);
@@ -111,7 +116,6 @@ const outroTitle = lang === 'es'
           data-cinematic-section
           aria-labelledby={`post-${slug}`}
         >
-          <!-- Per-section ambient glow (subtle so the list doesn't feel saturated) -->
           <div aria-hidden="true" class={`pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br ${accent.glow} via-transparent to-transparent opacity-30`}></div>
           <div aria-hidden="true" class="pointer-events-none absolute inset-x-0 top-0 -z-10 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent"></div>
 
@@ -231,7 +235,7 @@ const outroTitle = lang === 'es'
       );
     })}
 
-    {publishedPosts.length === 0 && (
+    {posts.length === 0 && (
       <div class="mx-auto max-w-3xl px-6 py-24">
         <div class="rounded-2xl border border-white/10 bg-gradient-to-br from-ink-800 to-ink-900 p-12 text-center">
           <h3 class="mb-2 text-lg font-semibold text-slate-100">{t(lang, 'blog.noPosts')}</h3>
@@ -240,8 +244,18 @@ const outroTitle = lang === 'es'
       </div>
     )}
 
-    <!-- Outro -->
-    {publishedPosts.length > 0 && (
+    {totalPages > 1 && posts.length > 0 && (
+      <BlogPagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        prevUrl={prevUrl}
+        nextUrl={nextUrl}
+        lang={lang}
+      />
+    )}
+
+    <!-- Outro: solo en la última página -->
+    {currentPage === totalPages && posts.length > 0 && (
       <footer class="relative flex min-h-[45vh] items-center justify-center px-6 py-24 text-center">
         <div aria-hidden="true" class="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
           <div class="absolute inset-0 bg-gradient-to-b from-transparent via-accent-violet/5 to-transparent"></div>

--- a/src/components/blog/BlogContent.astro
+++ b/src/components/blog/BlogContent.astro
@@ -95,49 +95,19 @@ const outroTitle = lang === 'es'
   <div class="blog-cinematic relative min-h-screen">
     <DotField />
 
-    <!-- Hero — full cinematic on page 1, compact on subsequent pages -->
-    {currentPage === 1 ? (
-      <header class="relative flex min-h-screen items-center justify-center px-6 pb-24 pt-32 text-center">
-        <div aria-hidden="true" class="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-          <div class="absolute left-1/2 top-1/2 hidden h-[40rem] w-[40rem] -translate-x-1/2 -translate-y-1/2 rounded-full bg-gradient-conic from-accent-violet/30 via-accent-blue/20 to-accent-sky/30 blur-[120px] dark:block"></div>
-        </div>
-
-        <div class="w-full max-w-xl">
+    <header class="flex items-end px-6 pb-8 pt-32">
+      <div class="mx-auto flex w-full max-w-5xl items-end justify-between gap-6">
+        <div>
           <p class="font-mono text-xs uppercase tracking-[0.4em] text-secondary dark:text-accent-blue">
             {t(lang, 'blog.eyebrow')}
           </p>
-          <h1 class="mt-6 font-display text-6xl font-black leading-none tracking-tight text-ink-900 dark:text-slate-50 sm:text-7xl md:text-8xl">
+          <h1 class="mt-2 font-display text-3xl font-black tracking-tight text-ink-900 dark:text-slate-50 sm:text-4xl">
             Blog
           </h1>
-          <p class="mx-auto mt-6 text-base leading-relaxed text-slate-600 dark:text-slate-400 sm:text-lg">
-            {t(lang, 'blog.subtitle')}
-          </p>
-
-          <BlogSearch lang={lang} ctaLabel={ctaLabel} class="mt-8 w-full" />
-
-          <div class="mt-10 flex flex-col items-center gap-3" aria-hidden="true">
-            <span class="font-mono text-[10px] uppercase tracking-[0.3em] text-secondary dark:text-accent-blue">
-              Scroll
-            </span>
-            <div class="cinematic-scroll-line"></div>
-          </div>
         </div>
-      </header>
-    ) : (
-      <header class="flex items-end px-6 pb-8 pt-32">
-        <div class="mx-auto w-full max-w-5xl space-y-4">
-          <div>
-            <p class="font-mono text-xs uppercase tracking-[0.4em] text-secondary dark:text-accent-blue">
-              {t(lang, 'blog.eyebrow')}
-            </p>
-            <h1 class="mt-2 font-display text-3xl font-black tracking-tight text-ink-900 dark:text-slate-50 sm:text-4xl">
-              Blog
-            </h1>
-          </div>
-          <BlogSearch lang={lang} ctaLabel={ctaLabel} class="max-w-sm" />
-        </div>
-      </header>
-    )}
+        <BlogSearch lang={lang} ctaLabel={ctaLabel} class="w-full max-w-xs" />
+      </div>
+    </header>
 
     <!-- Posts list (hidden when search is active) -->
     <div id="blog-posts">

--- a/src/components/blog/BlogContent.astro
+++ b/src/components/blog/BlogContent.astro
@@ -109,6 +109,7 @@ const outroTitle = lang === 'es'
       const postUrl = lang === 'en' ? `/en/blog/${slug}` : `/blog/${slug}`;
       const reading = calculateReadingTime(post.body || '', lang);
       const tags = post.data.tags.slice(0, 3);
+      const number = String(i + 1).padStart(2, '0');
       return (
         <article
           class="cinematic-section relative px-6 py-12 md:py-16"
@@ -126,6 +127,9 @@ const outroTitle = lang === 'es'
             >
               <div class="space-y-4">
                 <div class="flex items-baseline gap-3">
+                  <span class={`font-display text-3xl font-black tracking-tighter ${accent.text} md:text-4xl`}>
+                    {number}
+                  </span>
                   <span class="font-mono text-[10px] uppercase tracking-[0.25em] text-slate-500 dark:text-slate-400 normal-case tracking-normal text-xs">
                     {formatDate(post.data.publishDate, lang === 'es' ? 'es-ES' : 'en-US')}
                   </span>

--- a/src/components/blog/BlogContent.astro
+++ b/src/components/blog/BlogContent.astro
@@ -74,33 +74,46 @@ const outroTitle = lang === 'es'
   <div class="blog-cinematic relative min-h-screen">
     <DotField />
 
-    <!-- Hero -->
-    <header class="relative flex min-h-screen items-center justify-center px-6 pb-24 pt-32 text-center">
-      <div aria-hidden="true" class="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-        <div class="absolute left-1/2 top-1/2 hidden h-[40rem] w-[40rem] -translate-x-1/2 -translate-y-1/2 rounded-full bg-gradient-conic from-accent-violet/30 via-accent-blue/20 to-accent-sky/30 blur-[120px] dark:block"></div>
-      </div>
-
-      <div>
-        <p class="font-mono text-xs uppercase tracking-[0.4em] text-secondary dark:text-accent-blue">
-          {t(lang, 'blog.eyebrow')}
-        </p>
-        <h1
-          class="mt-6 font-display text-6xl font-black leading-none tracking-tight text-ink-900 dark:text-slate-50 sm:text-7xl md:text-8xl"
-        >
-          Blog
-        </h1>
-        <p class="mx-auto mt-6 max-w-xl text-base leading-relaxed text-slate-600 dark:text-slate-400 sm:text-lg">
-          {t(lang, 'blog.subtitle')}
-        </p>
-
-        <div class="mt-12 flex flex-col items-center gap-3" aria-hidden="true">
-          <span class="font-mono text-[10px] uppercase tracking-[0.3em] text-secondary dark:text-accent-blue">
-            Scroll
-          </span>
-          <div class="cinematic-scroll-line"></div>
+    <!-- Hero — full cinematic en página 1, compacto en páginas siguientes -->
+    {currentPage === 1 ? (
+      <header class="relative flex min-h-screen items-center justify-center px-6 pb-24 pt-32 text-center">
+        <div aria-hidden="true" class="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+          <div class="absolute left-1/2 top-1/2 hidden h-[40rem] w-[40rem] -translate-x-1/2 -translate-y-1/2 rounded-full bg-gradient-conic from-accent-violet/30 via-accent-blue/20 to-accent-sky/30 blur-[120px] dark:block"></div>
         </div>
-      </div>
-    </header>
+
+        <div>
+          <p class="font-mono text-xs uppercase tracking-[0.4em] text-secondary dark:text-accent-blue">
+            {t(lang, 'blog.eyebrow')}
+          </p>
+          <h1
+            class="mt-6 font-display text-6xl font-black leading-none tracking-tight text-ink-900 dark:text-slate-50 sm:text-7xl md:text-8xl"
+          >
+            Blog
+          </h1>
+          <p class="mx-auto mt-6 max-w-xl text-base leading-relaxed text-slate-600 dark:text-slate-400 sm:text-lg">
+            {t(lang, 'blog.subtitle')}
+          </p>
+
+          <div class="mt-12 flex flex-col items-center gap-3" aria-hidden="true">
+            <span class="font-mono text-[10px] uppercase tracking-[0.3em] text-secondary dark:text-accent-blue">
+              Scroll
+            </span>
+            <div class="cinematic-scroll-line"></div>
+          </div>
+        </div>
+      </header>
+    ) : (
+      <header class="flex items-end px-6 pb-8 pt-32">
+        <div class="mx-auto w-full max-w-5xl">
+          <p class="font-mono text-xs uppercase tracking-[0.4em] text-secondary dark:text-accent-blue">
+            {t(lang, 'blog.eyebrow')}
+          </p>
+          <h1 class="mt-2 font-display text-3xl font-black tracking-tight text-ink-900 dark:text-slate-50 sm:text-4xl">
+            Blog
+          </h1>
+        </div>
+      </header>
+    )}
 
     <!-- Posts as cinematic sections -->
     {posts.length > 0 && posts.map((post, i) => {

--- a/src/components/blog/BlogContent.astro
+++ b/src/components/blog/BlogContent.astro
@@ -15,14 +15,13 @@ interface Props {
   posts: CollectionEntry<'blog'>[];
   currentPage: number;
   totalPages: number;
-  totalPosts: number;
-  pageOffset: number;
+  firstPostNumber: number;
   prevUrl?: string;
   nextUrl?: string;
   alternateUrl: string;
 }
 
-const { lang, posts, currentPage, totalPages, totalPosts, pageOffset, prevUrl, nextUrl, alternateUrl } = Astro.props;
+const { lang, posts, currentPage, totalPages, firstPostNumber, prevUrl, nextUrl, alternateUrl } = Astro.props;
 const blogPath = lang === 'en' ? '/en/blog' : '/blog';
 
 const accentCycle = ['violet', 'blue', 'emerald', 'sky'] as const;
@@ -111,7 +110,7 @@ const outroTitle = lang === 'es'
       const postUrl = lang === 'en' ? `/en/blog/${slug}` : `/blog/${slug}`;
       const reading = calculateReadingTime(post.body || '', lang);
       const tags = post.data.tags.slice(0, 3);
-      const number = String(totalPosts - (pageOffset + i)).padStart(2, '0');
+      const number = String(firstPostNumber - i).padStart(2, '0');
       return (
         <article
           class="cinematic-section relative px-6 py-12 md:py-16"

--- a/src/components/blog/BlogContent.astro
+++ b/src/components/blog/BlogContent.astro
@@ -44,11 +44,11 @@ const searchIndexJson = JSON.stringify(searchIndex).replace(/<\/script>/gi, '<\\
 
 const accentCycle = ['violet', 'blue', 'emerald', 'sky'] as const;
 type Accent = (typeof accentCycle)[number];
-const accentMap: Record<Accent, { text: string; bg: string; ring: string; glow: string; line: string }> = {
-  violet:  { text: 'text-accent-violet',  bg: 'bg-accent-violet',  ring: 'ring-accent-violet/40',  glow: 'from-accent-violet/30', line: 'via-accent-violet/25' },
-  blue:    { text: 'text-accent-blue',    bg: 'bg-accent-blue',    ring: 'ring-accent-blue/40',    glow: 'from-accent-blue/30',   line: 'via-accent-blue/25' },
-  emerald: { text: 'text-emerald-400',    bg: 'bg-emerald-400',    ring: 'ring-emerald-400/40',    glow: 'from-emerald-400/25',   line: 'via-emerald-400/20' },
-  sky:     { text: 'text-accent-sky',     bg: 'bg-accent-sky',     ring: 'ring-accent-sky/40',     glow: 'from-accent-sky/25',    line: 'via-accent-sky/20' },
+const accentMap: Record<Accent, { text: string; bg: string; ring: string; glow: string; line: string; softBg: string }> = {
+  violet:  { text: 'text-accent-violet',  bg: 'bg-accent-violet',  ring: 'ring-accent-violet/40',  glow: 'from-accent-violet/30', line: 'via-accent-violet/25', softBg: 'via-accent-violet/[0.07]' },
+  blue:    { text: 'text-accent-blue',    bg: 'bg-accent-blue',    ring: 'ring-accent-blue/40',    glow: 'from-accent-blue/30',   line: 'via-accent-blue/25',   softBg: 'via-accent-blue/[0.07]' },
+  emerald: { text: 'text-emerald-400',    bg: 'bg-emerald-400',    ring: 'ring-emerald-400/40',    glow: 'from-emerald-400/25',   line: 'via-emerald-400/20',   softBg: 'via-emerald-400/[0.06]' },
+  sky:     { text: 'text-accent-sky',     bg: 'bg-accent-sky',     ring: 'ring-accent-sky/40',     glow: 'from-accent-sky/25',    line: 'via-accent-sky/20',    softBg: 'via-accent-sky/[0.06]' },
 };
 
 const ctaLabel = lang === 'es' ? 'Leer artículo' : 'Read article';
@@ -125,6 +125,7 @@ const outroTitle = lang === 'es'
             data-cinematic-section
             aria-labelledby={`post-${slug}`}
           >
+            <div aria-hidden="true" class={`pointer-events-none absolute inset-0 bg-gradient-to-r from-transparent ${accent.softBg} to-transparent`}></div>
             <div aria-hidden="true" class={`pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent ${accent.line} to-transparent`}></div>
 
             <div class="mx-auto grid w-full max-w-5xl grid-cols-1 items-center gap-8 md:grid-cols-12 md:gap-10 lg:gap-12">

--- a/src/components/blog/BlogContent.astro
+++ b/src/components/blog/BlogContent.astro
@@ -1,10 +1,12 @@
 ---
+import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
 import Layout from '@/layouts/Layout.astro';
 import DotField from '@/components/shared/DotField.astro';
 import Tag from '@/components/shared/Tag.astro';
 import BlogPagination from '@/components/blog/BlogPagination.astro';
-import { calculateReadingTime } from '@/lib/blog';
+import BlogSearch from '@/components/blog/BlogSearch.astro';
+import { calculateReadingTime, sortPostsByDate, filterDrafts } from '@/lib/blog';
 import { formatDate } from '@/lib/date';
 import { t, getBlogSlugFromId } from '@/i18n/utils';
 import type { Lang } from '@/i18n/types';
@@ -23,6 +25,22 @@ interface Props {
 
 const { lang, posts, currentPage, totalPages, firstPostNumber, prevUrl, nextUrl, alternateUrl } = Astro.props;
 const blogPath = lang === 'en' ? '/en/blog' : '/blog';
+
+// Build search index from all posts (not just current page)
+const allBlogPosts = await getCollection('blog');
+const searchIndex = sortPostsByDate(filterDrafts(allBlogPosts))
+  .filter((p) => p.id.startsWith(`${lang}/`))
+  .map((post) => {
+    const slug = getBlogSlugFromId(post.id);
+    return {
+      title: post.data.title,
+      description: post.data.description,
+      tags: post.data.tags,
+      url: lang === 'en' ? `/en/blog/${slug}` : `/blog/${slug}`,
+      date: formatDate(post.data.publishDate, lang === 'es' ? 'es-ES' : 'en-US'),
+    };
+  });
+const searchIndexJson = JSON.stringify(searchIndex).replace(/<\/script>/gi, '<\\/script>');
 
 const accentCycle = ['violet', 'blue', 'emerald', 'sky'] as const;
 type Accent = (typeof accentCycle)[number];
@@ -71,30 +89,33 @@ const outroTitle = lang === 'es'
     })} />
   </Fragment>
 
+  <!-- Search index: all posts, read by the client-side search script -->
+  <script is:inline id="blog-search-index" type="application/json" set:html={searchIndexJson} />
+
   <div class="blog-cinematic relative min-h-screen">
     <DotField />
 
-    <!-- Hero — full cinematic en página 1, compacto en páginas siguientes -->
+    <!-- Hero — full cinematic on page 1, compact on subsequent pages -->
     {currentPage === 1 ? (
       <header class="relative flex min-h-screen items-center justify-center px-6 pb-24 pt-32 text-center">
         <div aria-hidden="true" class="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
           <div class="absolute left-1/2 top-1/2 hidden h-[40rem] w-[40rem] -translate-x-1/2 -translate-y-1/2 rounded-full bg-gradient-conic from-accent-violet/30 via-accent-blue/20 to-accent-sky/30 blur-[120px] dark:block"></div>
         </div>
 
-        <div>
+        <div class="w-full max-w-xl">
           <p class="font-mono text-xs uppercase tracking-[0.4em] text-secondary dark:text-accent-blue">
             {t(lang, 'blog.eyebrow')}
           </p>
-          <h1
-            class="mt-6 font-display text-6xl font-black leading-none tracking-tight text-ink-900 dark:text-slate-50 sm:text-7xl md:text-8xl"
-          >
+          <h1 class="mt-6 font-display text-6xl font-black leading-none tracking-tight text-ink-900 dark:text-slate-50 sm:text-7xl md:text-8xl">
             Blog
           </h1>
-          <p class="mx-auto mt-6 max-w-xl text-base leading-relaxed text-slate-600 dark:text-slate-400 sm:text-lg">
+          <p class="mx-auto mt-6 text-base leading-relaxed text-slate-600 dark:text-slate-400 sm:text-lg">
             {t(lang, 'blog.subtitle')}
           </p>
 
-          <div class="mt-12 flex flex-col items-center gap-3" aria-hidden="true">
+          <BlogSearch lang={lang} ctaLabel={ctaLabel} class="mt-8 w-full" />
+
+          <div class="mt-10 flex flex-col items-center gap-3" aria-hidden="true">
             <span class="font-mono text-[10px] uppercase tracking-[0.3em] text-secondary dark:text-accent-blue">
               Scroll
             </span>
@@ -104,187 +125,174 @@ const outroTitle = lang === 'es'
       </header>
     ) : (
       <header class="flex items-end px-6 pb-8 pt-32">
-        <div class="mx-auto w-full max-w-5xl">
-          <p class="font-mono text-xs uppercase tracking-[0.4em] text-secondary dark:text-accent-blue">
-            {t(lang, 'blog.eyebrow')}
-          </p>
-          <h1 class="mt-2 font-display text-3xl font-black tracking-tight text-ink-900 dark:text-slate-50 sm:text-4xl">
-            Blog
-          </h1>
+        <div class="mx-auto w-full max-w-5xl space-y-4">
+          <div>
+            <p class="font-mono text-xs uppercase tracking-[0.4em] text-secondary dark:text-accent-blue">
+              {t(lang, 'blog.eyebrow')}
+            </p>
+            <h1 class="mt-2 font-display text-3xl font-black tracking-tight text-ink-900 dark:text-slate-50 sm:text-4xl">
+              Blog
+            </h1>
+          </div>
+          <BlogSearch lang={lang} ctaLabel={ctaLabel} class="max-w-sm" />
         </div>
       </header>
     )}
 
-    <!-- Posts as cinematic sections -->
-    {posts.length > 0 && posts.map((post, i) => {
-      const accent = accentMap[accentCycle[i % accentCycle.length]];
-      const flip = i % 2 === 1;
-      const slug = getBlogSlugFromId(post.id);
-      const postUrl = lang === 'en' ? `/en/blog/${slug}` : `/blog/${slug}`;
-      const reading = calculateReadingTime(post.body || '', lang);
-      const tags = post.data.tags.slice(0, 3);
-      const number = String(firstPostNumber - i).padStart(2, '0');
-      return (
-        <article
-          class="cinematic-section relative px-6 py-12 md:py-16"
-          data-cinematic-section
-          aria-labelledby={`post-${slug}`}
-        >
-          <div aria-hidden="true" class={`pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br ${accent.glow} via-transparent to-transparent opacity-30`}></div>
-          <div aria-hidden="true" class="pointer-events-none absolute inset-x-0 top-0 -z-10 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent"></div>
+    <!-- Posts list (hidden when search is active) -->
+    <div id="blog-posts">
+      {posts.length > 0 && posts.map((post, i) => {
+        const accent = accentMap[accentCycle[i % accentCycle.length]];
+        const flip = i % 2 === 1;
+        const slug = getBlogSlugFromId(post.id);
+        const postUrl = lang === 'en' ? `/en/blog/${slug}` : `/blog/${slug}`;
+        const reading = calculateReadingTime(post.body || '', lang);
+        const tags = post.data.tags.slice(0, 3);
+        const number = String(firstPostNumber - i).padStart(2, '0');
+        return (
+          <article
+            class="cinematic-section relative px-6 py-12 md:py-16"
+            data-cinematic-section
+            aria-labelledby={`post-${slug}`}
+          >
+            <div aria-hidden="true" class={`pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br ${accent.glow} via-transparent to-transparent opacity-30`}></div>
+            <div aria-hidden="true" class="pointer-events-none absolute inset-x-0 top-0 -z-10 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent"></div>
 
-          <div class="mx-auto grid w-full max-w-5xl grid-cols-1 items-center gap-8 md:grid-cols-12 md:gap-10 lg:gap-12">
-            <!-- Meta -->
-            <div
-              class={`md:col-span-6 lg:col-span-6 ${flip ? 'md:order-2' : ''}`}
-              data-cinematic-meta
-            >
-              <div class="space-y-4">
-                <div class="flex items-baseline gap-3">
-                  <span class={`font-display text-3xl font-black tracking-tighter ${accent.text} md:text-4xl`}>
-                    {number}
-                  </span>
-                  <span class="font-mono text-[10px] uppercase tracking-[0.25em] text-slate-500 dark:text-slate-400 normal-case tracking-normal text-xs">
-                    {formatDate(post.data.publishDate, lang === 'es' ? 'es-ES' : 'en-US')}
-                  </span>
-                  <span class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
-                    · {reading.minutes} min
-                  </span>
-                  {post.data.featured && (
-                    <span class={`inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.25em] ${accent.text}`}>
-                      <span class={`h-1.5 w-1.5 rounded-full ${accent.bg} animate-pulse`}></span>
-                      {featuredLabel}
+            <div class="mx-auto grid w-full max-w-5xl grid-cols-1 items-center gap-8 md:grid-cols-12 md:gap-10 lg:gap-12">
+              <div class={`md:col-span-6 lg:col-span-6 ${flip ? 'md:order-2' : ''}`} data-cinematic-meta>
+                <div class="space-y-4">
+                  <div class="flex items-baseline gap-3">
+                    <span class={`font-display text-3xl font-black tracking-tighter ${accent.text} md:text-4xl`}>
+                      {number}
                     </span>
-                  )}
-                </div>
+                    <span class="normal-case text-xs tracking-normal font-mono text-slate-500 dark:text-slate-400">
+                      {formatDate(post.data.publishDate, lang === 'es' ? 'es-ES' : 'en-US')}
+                    </span>
+                    <span class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                      · {reading.minutes} min
+                    </span>
+                    {post.data.featured && (
+                      <span class={`inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.25em] ${accent.text}`}>
+                        <span class={`h-1.5 w-1.5 rounded-full ${accent.bg} animate-pulse`}></span>
+                        {featuredLabel}
+                      </span>
+                    )}
+                  </div>
 
-                <h2
-                  id={`post-${slug}`}
-                  class="font-display text-2xl font-black leading-tight tracking-tight text-ink-900 dark:text-slate-50 md:text-3xl"
-                >
+                  <h2
+                    id={`post-${slug}`}
+                    class="font-display text-2xl font-black leading-tight tracking-tight text-ink-900 dark:text-slate-50 md:text-3xl"
+                  >
+                    <a
+                      href={postUrl}
+                      class="transition-colors duration-200 hover:text-secondary focus:text-secondary focus:outline-none focus-visible:underline dark:hover:text-accent-violet dark:focus:text-accent-violet"
+                    >
+                      {post.data.title}
+                    </a>
+                  </h2>
+
+                  <p class="text-sm leading-relaxed text-slate-700 dark:text-slate-300 line-clamp-3">
+                    {post.data.description}
+                  </p>
+
+                  {tags.length > 0 && (
+                    <ul class="flex flex-wrap gap-2 list-none p-0" aria-label={t(lang, 'blog.tags')}>
+                      {tags.map((tag) => (
+                        <li><Tag label={tag} variant="accent" /></li>
+                      ))}
+                    </ul>
+                  )}
+
                   <a
                     href={postUrl}
-                    class="transition-colors duration-200 hover:text-secondary focus:text-secondary focus:outline-none focus-visible:underline dark:hover:text-accent-violet dark:focus:text-accent-violet"
+                    class={`group inline-flex items-center gap-3 font-mono text-xs uppercase tracking-[0.25em] ${accent.text} focus:outline-none focus-visible:underline`}
                   >
-                    {post.data.title}
+                    <span>{ctaLabel}</span>
+                    <span class={`relative h-px w-10 ${accent.bg} transition-all duration-500 group-hover:w-16`}></span>
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4 transition-transform duration-500 group-hover:translate-x-1" aria-hidden="true">
+                      <path d="M5 12h14M13 5l7 7-7 7" />
+                    </svg>
                   </a>
-                </h2>
+                </div>
+              </div>
 
-                <p class="text-sm leading-relaxed text-slate-700 dark:text-slate-300 line-clamp-3">
-                  {post.data.description}
-                </p>
-
-                {tags.length > 0 && (
-                  <ul class="flex flex-wrap gap-2 list-none p-0" aria-label={t(lang, 'blog.tags')}>
-                    {tags.map((tag) => (
-                      <li><Tag label={tag} variant="accent" /></li>
-                    ))}
-                  </ul>
-                )}
-
+              <div class={`md:col-span-6 lg:col-span-6 ${flip ? 'md:order-1' : ''}`} data-cinematic-visual>
                 <a
                   href={postUrl}
-                  class={`group inline-flex items-center gap-3 font-mono text-xs uppercase tracking-[0.25em] ${accent.text} focus:outline-none focus-visible:underline`}
+                  class={`cinematic-mock ${flip ? 'cinematic-mock--flip' : ''} block relative overflow-hidden rounded-xl border border-white/10 bg-gradient-to-br from-ink-800 to-ink-900 p-1 shadow-xl ring-1 ${accent.ring} focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-blue`}
+                  aria-label={`${ctaLabel}: ${post.data.title}`}
                 >
-                  <span>{ctaLabel}</span>
-                  <span class={`relative h-px w-10 ${accent.bg} transition-all duration-500 group-hover:w-16`}></span>
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    class="h-4 w-4 transition-transform duration-500 group-hover:translate-x-1"
-                    aria-hidden="true"
-                  >
-                    <path d="M5 12h14M13 5l7 7-7 7" />
-                  </svg>
+                  <div class="flex items-center gap-1.5 border-b border-white/5 bg-ink-800/95 px-3 py-2 backdrop-blur">
+                    <span class="h-2 w-2 rounded-full bg-red-400/70"></span>
+                    <span class="h-2 w-2 rounded-full bg-yellow-400/70"></span>
+                    <span class="h-2 w-2 rounded-full bg-green-400/70"></span>
+                    <span class="ml-3 font-mono text-[9px] text-slate-400 truncate">aitorevi.dev{postUrl}</span>
+                  </div>
+                  <div class="relative aspect-video w-full overflow-hidden bg-ink-900">
+                    {post.data.coverImage ? (
+                      <img
+                        src={post.data.coverImage}
+                        alt={post.data.coverImageAlt || post.data.title}
+                        width="1200"
+                        height="675"
+                        class="h-full w-full object-cover"
+                        loading={i < 2 ? 'eager' : 'lazy'}
+                        decoding={i < 2 ? 'sync' : 'async'}
+                      />
+                    ) : (
+                      <div class="flex h-full w-full items-center justify-center bg-gradient-to-br from-ink-800 to-ink-900">
+                        <span class="select-none font-display text-4xl font-black tracking-tight text-slate-50">
+                          aitorevi<span class={accent.text}>.</span>
+                        </span>
+                      </div>
+                    )}
+                  </div>
                 </a>
               </div>
             </div>
+          </article>
+        );
+      })}
 
-            <!-- Visual -->
-            <div
-              class={`md:col-span-6 lg:col-span-6 ${flip ? 'md:order-1' : ''}`}
-              data-cinematic-visual
-            >
-              <a
-                href={postUrl}
-                class={`cinematic-mock ${flip ? 'cinematic-mock--flip' : ''} block relative overflow-hidden rounded-xl border border-white/10 bg-gradient-to-br from-ink-800 to-ink-900 p-1 shadow-xl ring-1 ${accent.ring} focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-blue`}
-                aria-label={`${ctaLabel}: ${post.data.title}`}
-              >
-                <div class="flex items-center gap-1.5 border-b border-white/5 bg-ink-800/95 px-3 py-2 backdrop-blur">
-                  <span class="h-2 w-2 rounded-full bg-red-400/70"></span>
-                  <span class="h-2 w-2 rounded-full bg-yellow-400/70"></span>
-                  <span class="h-2 w-2 rounded-full bg-green-400/70"></span>
-                  <span class="ml-3 font-mono text-[9px] text-slate-400 truncate">
-                    aitorevi.dev{postUrl}
-                  </span>
-                </div>
-                <div class="relative aspect-video w-full overflow-hidden bg-ink-900">
-                  {post.data.coverImage ? (
-                    <img
-                      src={post.data.coverImage}
-                      alt={post.data.coverImageAlt || post.data.title}
-                      width="1200"
-                      height="675"
-                      class="h-full w-full object-cover"
-                      loading={i < 2 ? 'eager' : 'lazy'}
-                      decoding={i < 2 ? 'sync' : 'async'}
-                    />
-                  ) : (
-                    <div class="flex h-full w-full items-center justify-center bg-gradient-to-br from-ink-800 to-ink-900">
-                      <span class="select-none font-display text-4xl font-black tracking-tight text-slate-50">
-                        aitorevi<span class={accent.text}>.</span>
-                      </span>
-                    </div>
-                  )}
-                </div>
-              </a>
-            </div>
+      {posts.length === 0 && (
+        <div class="mx-auto max-w-3xl px-6 py-24">
+          <div class="rounded-2xl border border-white/10 bg-gradient-to-br from-ink-800 to-ink-900 p-12 text-center">
+            <h3 class="mb-2 text-lg font-semibold text-slate-100">{t(lang, 'blog.noPosts')}</h3>
+            <p class="text-slate-400">{t(lang, 'blog.noPostsDescription')}</p>
           </div>
-        </article>
-      );
-    })}
-
-    {posts.length === 0 && (
-      <div class="mx-auto max-w-3xl px-6 py-24">
-        <div class="rounded-2xl border border-white/10 bg-gradient-to-br from-ink-800 to-ink-900 p-12 text-center">
-          <h3 class="mb-2 text-lg font-semibold text-slate-100">{t(lang, 'blog.noPosts')}</h3>
-          <p class="text-slate-400">{t(lang, 'blog.noPostsDescription')}</p>
         </div>
-      </div>
-    )}
+      )}
 
-    {totalPages > 1 && posts.length > 0 && (
-      <BlogPagination
-        currentPage={currentPage}
-        totalPages={totalPages}
-        prevUrl={prevUrl}
-        nextUrl={nextUrl}
-        lang={lang}
-        basePath={blogPath}
-      />
-    )}
+      {totalPages > 1 && posts.length > 0 && (
+        <BlogPagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          prevUrl={prevUrl}
+          nextUrl={nextUrl}
+          lang={lang}
+          basePath={blogPath}
+        />
+      )}
 
-    <!-- Outro: solo en la última página -->
-    {currentPage === totalPages && posts.length > 0 && (
-      <footer class="relative flex min-h-[45vh] items-center justify-center px-6 py-24 text-center">
-        <div aria-hidden="true" class="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-          <div class="absolute inset-0 bg-gradient-to-b from-transparent via-accent-violet/5 to-transparent"></div>
-        </div>
-        <div>
-          <p class="font-mono text-xs uppercase tracking-[0.4em] text-secondary dark:text-accent-blue">
-            {t(lang, 'blog.outro.eyebrow')}
-          </p>
-          <h2 class="mt-6 font-display text-4xl font-black tracking-tight text-ink-900 dark:text-slate-50 md:text-6xl">
-            {outroTitle}
-          </h2>
-        </div>
-      </footer>
-    )}
+      {currentPage === totalPages && posts.length > 0 && (
+        <footer class="relative flex min-h-[45vh] items-center justify-center px-6 py-24 text-center">
+          <div aria-hidden="true" class="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+            <div class="absolute inset-0 bg-gradient-to-b from-transparent via-accent-violet/5 to-transparent"></div>
+          </div>
+          <div>
+            <p class="font-mono text-xs uppercase tracking-[0.4em] text-secondary dark:text-accent-blue">
+              {t(lang, 'blog.outro.eyebrow')}
+            </p>
+            <h2 class="mt-6 font-display text-4xl font-black tracking-tight text-ink-900 dark:text-slate-50 md:text-6xl">
+              {outroTitle}
+            </h2>
+          </div>
+        </footer>
+      )}
+    </div>
+
+    <!-- Search results (shown when search is active, replaces #blog-posts) -->
+    <div id="blog-search-results" hidden aria-label={t(lang, 'blog.search.label')}></div>
   </div>
 </Layout>
 
@@ -365,7 +373,106 @@ const outroTitle = lang === 'es'
   }
 </style>
 
+<style is:global>
+  /* Search result items — rendered via innerHTML so scoped styles don't apply */
+  .blog-search-result {
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+    padding: 2rem 1.5rem;
+  }
+  .blog-search-result:first-child {
+    border-top: none;
+  }
+  .blog-search-result__inner {
+    max-width: 64rem;
+    margin-inline: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .blog-result-date {
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 0.625rem;
+    color: rgb(100 116 139);
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+  }
+  .blog-result-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+  }
+  .blog-result-tag {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 9999px;
+    border: 1px solid rgba(139, 92, 246, 0.3);
+    background: rgba(139, 92, 246, 0.1);
+    padding: 0.125rem 0.625rem;
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 0.625rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: rgb(167 139 250);
+  }
+  .blog-result-title {
+    font-size: 1.25rem;
+    font-weight: 900;
+    line-height: 1.2;
+    letter-spacing: -0.025em;
+    color: rgb(15 23 42);
+  }
+  .dark .blog-result-title {
+    color: rgb(248 250 252);
+  }
+  .blog-result-link {
+    transition: color 200ms;
+    text-decoration: none;
+    color: inherit;
+  }
+  .blog-result-link:hover {
+    color: rgb(99 102 241);
+  }
+  .dark .blog-result-link:hover {
+    color: rgb(167 139 250);
+  }
+  .blog-result-desc {
+    font-size: 0.875rem;
+    line-height: 1.6;
+    color: rgb(71 85 105);
+  }
+  .dark .blog-result-desc {
+    color: rgb(203 213 225);
+  }
+  .blog-result-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 0.625rem;
+    text-transform: uppercase;
+    letter-spacing: 0.25em;
+    color: rgb(139 92 246);
+    text-decoration: none;
+    transition: opacity 200ms;
+  }
+  .blog-result-cta:hover { opacity: 0.7; }
+
+  .blog-search-empty {
+    padding: 6rem 1.5rem;
+    text-align: center;
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.3em;
+    color: rgb(100 116 139);
+  }
+  .dark .blog-search-empty {
+    color: rgb(71 85 105);
+  }
+</style>
+
 <script>
+  // ── Cinematic reveal ────────────────────────────────────────────────────────
   function setupCinematicReveal() {
     const sections = document.querySelectorAll<HTMLElement>('.blog-cinematic [data-cinematic-section]');
     if (!sections.length) return;
@@ -374,16 +481,91 @@ const outroTitle = lang === 'es'
       return;
     }
     const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) entry.target.classList.add('is-active');
-        });
-      },
+      (entries) => { entries.forEach((e) => { if (e.isIntersecting) e.target.classList.add('is-active'); }); },
       { threshold: 0.18, rootMargin: '0px 0px -10% 0px' }
     );
     sections.forEach((s) => observer.observe(s));
   }
+
+  // ── Blog search ─────────────────────────────────────────────────────────────
+  function setupBlogSearch() {
+    const input = document.querySelector<HTMLInputElement>('[data-blog-search-input]');
+    if (!input) return;
+
+    const indexEl = document.getElementById('blog-search-index');
+    if (!indexEl) return;
+
+    type Post = { title: string; description: string; tags: string[]; url: string; date: string };
+    let index: Post[] = [];
+    try { index = JSON.parse(indexEl.textContent || '[]'); } catch { return; }
+
+    const postsEl  = document.getElementById('blog-posts');
+    const resultsEl = document.getElementById('blog-search-results');
+    const liveEl   = document.getElementById('blog-search-live');
+
+    const emptyText   = input.dataset.empty       ?? '// sin resultados';
+    const resultsText = input.dataset.resultsText  ?? 'resultados';
+    const ctaLabel    = input.dataset.ctaLabel     ?? 'Leer';
+
+    const esc = (s: string) =>
+      s.replace(/[&<>"']/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c as '&'] ?? c));
+
+    function renderItem(post: Post): string {
+      const tagsHtml = post.tags.slice(0, 3)
+        .map((t) => `<span class="blog-result-tag">${esc(t)}</span>`).join('');
+      return `
+        <article class="blog-search-result">
+          <div class="blog-search-result__inner">
+            <p class="blog-result-date">${esc(post.date)}</p>
+            ${tagsHtml ? `<div class="blog-result-tags">${tagsHtml}</div>` : ''}
+            <h2 class="blog-result-title">
+              <a href="${esc(post.url)}" class="blog-result-link">${esc(post.title)}</a>
+            </h2>
+            <p class="blog-result-desc">${esc(post.description)}</p>
+            <a href="${esc(post.url)}" class="blog-result-cta" aria-hidden="true">${esc(ctaLabel)} →</a>
+          </div>
+        </article>`;
+    }
+
+    function showPosts() {
+      postsEl?.removeAttribute('hidden');
+      if (resultsEl) resultsEl.hidden = true;
+      if (liveEl)    liveEl.textContent = '';
+    }
+
+    function showResults(q: string) {
+      const matches = index.filter((p) =>
+        p.title.toLowerCase().includes(q) ||
+        p.description.toLowerCase().includes(q) ||
+        p.tags.some((t) => t.toLowerCase().includes(q))
+      );
+
+      postsEl?.setAttribute('hidden', '');
+      if (!resultsEl) return;
+      resultsEl.hidden = false;
+      resultsEl.innerHTML = matches.length
+        ? matches.map(renderItem).join('')
+        : `<p class="blog-search-empty">${esc(emptyText)}</p>`;
+
+      if (liveEl) liveEl.textContent = `${matches.length} ${resultsText}`;
+    }
+
+    let timer: ReturnType<typeof setTimeout>;
+    input.addEventListener('input', () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        const q = input.value.trim().toLowerCase();
+        q ? showResults(q) : showPosts();
+      }, 200);
+    });
+
+    // Reset on page navigation
+    input.value = '';
+    showPosts();
+  }
+
   setupCinematicReveal();
-  document.addEventListener('astro:page-load', setupCinematicReveal);
-  document.addEventListener('astro:after-swap', setupCinematicReveal);
+  setupBlogSearch();
+  document.addEventListener('astro:page-load', () => { setupCinematicReveal(); setupBlogSearch(); });
+  document.addEventListener('astro:after-swap', () => { setupCinematicReveal(); setupBlogSearch(); });
 </script>

--- a/src/components/blog/BlogPagination.astro
+++ b/src/components/blog/BlogPagination.astro
@@ -14,6 +14,32 @@ interface Props {
 const { currentPage, totalPages, prevUrl, nextUrl, lang, basePath } = Astro.props;
 
 const pageUrl = (n: number) => (n === 1 ? basePath : `${basePath}/${n}`);
+
+// Windowed range with ellipsis — always shows first, last, and ±1 around current.
+// Single-page gaps are filled (avoids "1 … 3" when 2 fits cleanly).
+function getPaginationRange(current: number, total: number): (number | '...')[] {
+  const delta = 1;
+  const core = new Set<number>([1, total]);
+  for (let i = Math.max(2, current - delta); i <= Math.min(total - 1, current + delta); i++) {
+    core.add(i);
+  }
+
+  const sorted = Array.from(core).sort((a, b) => a - b);
+  const result: (number | '...')[] = [];
+  let prev = 0;
+
+  for (const page of sorted) {
+    const gap = page - prev;
+    if (gap > 2) result.push('...');
+    else if (gap === 2) result.push(prev + 1); // fill single gap instead of ellipsis
+    result.push(page);
+    prev = page;
+  }
+
+  return result;
+}
+
+const range = getPaginationRange(currentPage, totalPages);
 ---
 
 <nav
@@ -31,30 +57,32 @@ const pageUrl = (n: number) => (n === 1 ? basePath : `${basePath}/${n}`);
     </a>
   )}
 
-  <ol class="flex items-center gap-1 list-none p-0" aria-label="páginas">
-    {Array.from({ length: totalPages }, (_, i) => {
-      const n = i + 1;
-      const isCurrent = n === currentPage;
-      return (
+  <ol class="flex items-center gap-1 list-none p-0">
+    {range.map((item) =>
+      item === '...' ? (
         <li>
-          {isCurrent ? (
-            <span
-              class="flex h-7 w-7 items-center justify-center rounded text-secondary dark:text-accent-blue font-black"
-              aria-current="page"
-            >
-              {n}
-            </span>
-          ) : (
-            <a
-              href={pageUrl(n)}
-              class="flex h-7 w-7 items-center justify-center rounded text-slate-400 dark:text-slate-500 hover:text-secondary dark:hover:text-accent-blue transition-colors motion-reduce:transition-none"
-            >
-              {n}
-            </a>
-          )}
+          <span class="flex h-7 w-7 items-center justify-center text-slate-400 dark:text-slate-600" aria-hidden="true">…</span>
         </li>
-      );
-    })}
+      ) : item === currentPage ? (
+        <li>
+          <span
+            class="flex h-7 w-7 items-center justify-center rounded font-black text-secondary dark:text-accent-blue"
+            aria-current="page"
+          >
+            {item}
+          </span>
+        </li>
+      ) : (
+        <li>
+          <a
+            href={pageUrl(item)}
+            class="flex h-7 w-7 items-center justify-center rounded text-slate-400 dark:text-slate-500 hover:text-secondary dark:hover:text-accent-blue transition-colors motion-reduce:transition-none"
+          >
+            {item}
+          </a>
+        </li>
+      )
+    )}
   </ol>
 
   {nextUrl && (

--- a/src/components/blog/BlogPagination.astro
+++ b/src/components/blog/BlogPagination.astro
@@ -1,0 +1,53 @@
+---
+import { t } from '@/i18n/utils';
+import type { Lang } from '@/i18n/types';
+
+interface Props {
+  currentPage: number;
+  totalPages: number;
+  prevUrl?: string;
+  nextUrl?: string;
+  lang: Lang;
+}
+
+const { currentPage, totalPages, prevUrl, nextUrl, lang } = Astro.props;
+---
+
+<nav
+  class="blog-pagination flex items-center justify-center gap-8 py-16 font-mono text-xs uppercase tracking-[0.2em]"
+  aria-label={t(lang, 'blog.pagination.nav')}
+>
+  {prevUrl ? (
+    <a
+      href={prevUrl}
+      class="flex items-center gap-2 text-secondary dark:text-accent-blue transition-opacity hover:opacity-70 motion-reduce:transition-none"
+      rel="prev"
+    >
+      <span aria-hidden="true">←</span>
+      <span>{t(lang, 'blog.pagination.prev')}</span>
+    </a>
+  ) : (
+    <span class="flex items-center gap-2 opacity-25" aria-hidden="true">
+      ← {t(lang, 'blog.pagination.prev')}
+    </span>
+  )}
+
+  <span class="text-slate-400 dark:text-slate-500" aria-current="page">
+    {currentPage} / {totalPages}
+  </span>
+
+  {nextUrl ? (
+    <a
+      href={nextUrl}
+      class="flex items-center gap-2 text-secondary dark:text-accent-blue transition-opacity hover:opacity-70 motion-reduce:transition-none"
+      rel="next"
+    >
+      <span>{t(lang, 'blog.pagination.next')}</span>
+      <span aria-hidden="true">→</span>
+    </a>
+  ) : (
+    <span class="flex items-center gap-2 opacity-25" aria-hidden="true">
+      {t(lang, 'blog.pagination.next')} →
+    </span>
+  )}
+</nav>

--- a/src/components/blog/BlogPagination.astro
+++ b/src/components/blog/BlogPagination.astro
@@ -8,16 +8,19 @@ interface Props {
   prevUrl?: string;
   nextUrl?: string;
   lang: Lang;
+  basePath: string;
 }
 
-const { currentPage, totalPages, prevUrl, nextUrl, lang } = Astro.props;
+const { currentPage, totalPages, prevUrl, nextUrl, lang, basePath } = Astro.props;
+
+const pageUrl = (n: number) => (n === 1 ? basePath : `${basePath}/${n}`);
 ---
 
 <nav
-  class="blog-pagination flex items-center justify-center gap-8 py-16 font-mono text-xs uppercase tracking-[0.2em]"
+  class="blog-pagination flex items-center justify-center gap-6 py-16 font-mono text-xs uppercase tracking-[0.2em]"
   aria-label={t(lang, 'blog.pagination.nav')}
 >
-  {prevUrl ? (
+  {prevUrl && (
     <a
       href={prevUrl}
       class="flex items-center gap-2 text-secondary dark:text-accent-blue transition-opacity hover:opacity-70 motion-reduce:transition-none"
@@ -26,17 +29,35 @@ const { currentPage, totalPages, prevUrl, nextUrl, lang } = Astro.props;
       <span aria-hidden="true">←</span>
       <span>{t(lang, 'blog.pagination.prev')}</span>
     </a>
-  ) : (
-    <span class="flex items-center gap-2 opacity-25" aria-hidden="true">
-      ← {t(lang, 'blog.pagination.prev')}
-    </span>
   )}
 
-  <span class="text-slate-400 dark:text-slate-500" aria-current="page">
-    {currentPage} / {totalPages}
-  </span>
+  <ol class="flex items-center gap-1 list-none p-0" aria-label="páginas">
+    {Array.from({ length: totalPages }, (_, i) => {
+      const n = i + 1;
+      const isCurrent = n === currentPage;
+      return (
+        <li>
+          {isCurrent ? (
+            <span
+              class="flex h-7 w-7 items-center justify-center rounded text-secondary dark:text-accent-blue font-black"
+              aria-current="page"
+            >
+              {n}
+            </span>
+          ) : (
+            <a
+              href={pageUrl(n)}
+              class="flex h-7 w-7 items-center justify-center rounded text-slate-400 dark:text-slate-500 hover:text-secondary dark:hover:text-accent-blue transition-colors motion-reduce:transition-none"
+            >
+              {n}
+            </a>
+          )}
+        </li>
+      );
+    })}
+  </ol>
 
-  {nextUrl ? (
+  {nextUrl && (
     <a
       href={nextUrl}
       class="flex items-center gap-2 text-secondary dark:text-accent-blue transition-opacity hover:opacity-70 motion-reduce:transition-none"
@@ -45,9 +66,5 @@ const { currentPage, totalPages, prevUrl, nextUrl, lang } = Astro.props;
       <span>{t(lang, 'blog.pagination.next')}</span>
       <span aria-hidden="true">→</span>
     </a>
-  ) : (
-    <span class="flex items-center gap-2 opacity-25" aria-hidden="true">
-      {t(lang, 'blog.pagination.next')} →
-    </span>
   )}
 </nav>

--- a/src/components/blog/BlogSearch.astro
+++ b/src/components/blog/BlogSearch.astro
@@ -1,0 +1,36 @@
+---
+import { t } from '@/i18n/utils';
+import type { Lang } from '@/i18n/types';
+
+interface Props {
+  lang: Lang;
+  ctaLabel: string;
+  class?: string;
+}
+
+const { lang, ctaLabel, class: className = '' } = Astro.props;
+---
+
+<form
+  role="search"
+  class={`blog-search ${className}`}
+  aria-label={t(lang, 'blog.search.label')}
+  onsubmit="return false"
+>
+  <input
+    id="blog-search-input"
+    type="search"
+    data-blog-search-input
+    data-lang={lang}
+    data-empty={t(lang, 'blog.search.empty')}
+    data-results-text={t(lang, 'blog.search.results')}
+    data-cta-label={ctaLabel}
+    placeholder={t(lang, 'blog.search.placeholder')}
+    autocomplete="off"
+    spellcheck="false"
+    class="w-full rounded-lg border border-white/20 bg-transparent px-4 py-2.5 font-mono text-sm text-slate-700 outline-none transition-colors duration-200 placeholder:text-slate-500 focus:border-accent-blue/60 dark:text-slate-200 dark:placeholder:text-slate-600 dark:focus:border-accent-blue/50 motion-reduce:transition-none"
+    aria-label={t(lang, 'blog.search.label')}
+  />
+</form>
+
+<div id="blog-search-live" role="status" aria-live="polite" class="sr-only"></div>

--- a/src/components/cv/CvScrollReveal.astro
+++ b/src/components/cv/CvScrollReveal.astro
@@ -157,6 +157,7 @@
     });
   }
 
+  initReveals();
   document.addEventListener('astro:page-load', () => {
     initReveals();
   });

--- a/src/content/blog/en/vercel-preview-deployments.md
+++ b/src/content/blog/en/vercel-preview-deployments.md
@@ -6,7 +6,7 @@ tags:
   - Vercel
   - DevOps
   - CLI
-draft: true
+draft: false
 featured: false
 author:
   name: aitorevi

--- a/src/i18n/messages/blog.ts
+++ b/src/i18n/messages/blog.ts
@@ -26,6 +26,10 @@ export const blog = {
     'blog.pagination.prev': 'Anterior',
     'blog.pagination.next': 'Siguiente',
     'blog.pagination.nav': 'Paginación del blog',
+    'blog.search.placeholder': '// buscar artículos…',
+    'blog.search.label': 'Buscar artículos',
+    'blog.search.empty': '// sin resultados',
+    'blog.search.results': 'resultados',
   },
   en: {
     'blog.copyCode': 'Copy',
@@ -54,5 +58,9 @@ export const blog = {
     'blog.pagination.prev': 'Previous',
     'blog.pagination.next': 'Next',
     'blog.pagination.nav': 'Blog pagination',
+    'blog.search.placeholder': '// search articles…',
+    'blog.search.label': 'Search articles',
+    'blog.search.empty': '// no results',
+    'blog.search.results': 'results',
   },
 };

--- a/src/i18n/messages/blog.ts
+++ b/src/i18n/messages/blog.ts
@@ -23,6 +23,9 @@ export const blog = {
     'blog.republished.linkLabel': 'Leer en el sitio original',
     'blog.crosspost.label': 'Crosspost',
     'blog.crosspost.aria': 'Publicado originalmente fuera de este blog',
+    'blog.pagination.prev': 'Anterior',
+    'blog.pagination.next': 'Siguiente',
+    'blog.pagination.nav': 'Paginación del blog',
   },
   en: {
     'blog.copyCode': 'Copy',
@@ -48,5 +51,8 @@ export const blog = {
     'blog.republished.linkLabel': 'Read on the original site',
     'blog.crosspost.label': 'Crosspost',
     'blog.crosspost.aria': 'Originally published off-site',
+    'blog.pagination.prev': 'Previous',
+    'blog.pagination.next': 'Next',
+    'blog.pagination.nav': 'Blog pagination',
   },
 };

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -58,3 +58,21 @@ export function filterDrafts<T extends { data: { draft?: boolean } }>(
 ): T[] {
   return isProd ? posts.filter((post) => !post.data.draft) : posts;
 }
+
+/**
+ * Filter posts by a search query against title, description and tags.
+ * Returns all posts when the query is empty or whitespace-only.
+ */
+export function filterPostsByQuery<T extends { title: string; description: string; tags: string[] }>(
+  posts: T[],
+  query: string
+): T[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return posts;
+  return posts.filter(
+    (p) =>
+      p.title.toLowerCase().includes(q) ||
+      p.description.toLowerCase().includes(q) ||
+      p.tags.some((tag) => tag.toLowerCase().includes(q))
+  );
+}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,29 +1,4 @@
 ---
-/**
- * Dynamic Blog Post Page
- *
- * Handles individual blog post rendering using Astro 5's Content Layer API.
- *
- * Static Generation Strategy:
- * - All routes generated at build time via getStaticPaths()
- * - Zero runtime overhead (SSG)
- * - Optimal Core Web Vitals (LCP, FID, CLS)
- *
- * SEO Optimizations:
- * - Semantic HTML5 structure
- * - Complete Open Graph metadata
- * - Schema.org Article markup
- * - Canonical URLs
- * - Minimal CSS (Tailwind utilities)
- * - View Transitions for SPA-like navigation
- *
- * Accessibility:
- * - Proper heading hierarchy (h1 → h2 → h3)
- * - ARIA landmarks
- * - High contrast ratios
- * - Keyboard navigation
- */
-
 import { getCollection, type CollectionEntry, render } from 'astro:content';
 import Layout from '@/layouts/Layout.astro';
 import Tag from '@/components/shared/Tag.astro';
@@ -40,7 +15,6 @@ import { safeJsonLd } from '@/lib/schema-org';
 
 const lang = 'es';
 
-// Astro 5: Generate static paths for Spanish blog posts
 export async function getStaticPaths() {
   const blogPosts = await getCollection('blog');
 
@@ -71,14 +45,9 @@ interface Props {
 const { post, alternateUrl } = Astro.props;
 const { data, body = '' } = post;
 
-
-// Astro 5: render() function for MDX/Markdown content
 const { Content } = await render(post);
 
-// Calculate reading time
 const readingTime = calculateReadingTime(body, lang);
-
-// Construct canonical URL
 const canonicalUrl = data.canonicalUrl || new URL(Astro.url.pathname, Astro.site).href;
 
 const DEFAULT_COVER_IMAGE = '/logo.webp';
@@ -97,9 +66,7 @@ const coverImageAbsolute = toAbsoluteUrl(coverImageUrl);
   canonicalUrl={canonicalUrl}
   variant="dark-radial"
 >
-  <!-- SEO: Open Graph & Twitter Card -->
   <Fragment slot="head">
-    <!-- Open Graph -->
     <meta property="og:type" content="article" />
     <meta property="og:title" content={data.title} />
     <meta property="og:description" content={data.description} />
@@ -113,13 +80,11 @@ const coverImageAbsolute = toAbsoluteUrl(coverImageUrl);
       <meta property="article:tag" content={tag} />
     ))}
 
-    <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={data.title} />
     <meta name="twitter:description" content={data.description} />
     <meta name="twitter:image" content={ogImageAbsolute} />
 
-    <!-- Schema.org JSON-LD -->
     <script is:inline type="application/ld+json" set:html={safeJsonLd({
       "@context": "https://schema.org",
       "@type": "BlogPosting",
@@ -146,149 +111,119 @@ const coverImageAbsolute = toAbsoluteUrl(coverImageUrl);
     })} />
   </Fragment>
 
-  <div class="relative min-h-screen">
+  <div class="blog-cinematic relative min-h-screen">
     <!-- Dark-mode-only dot field -->
     <DotField position="fixed" />
 
-  <!-- Main Article Content -->
-  <article
-    class="blog-page mx-auto max-w-screen-xl mt-16 md:mt-24 mb-2 md:mb-4 p-6 sm:p-7 md:p-8 lg:p-20"
-    itemscope
-    itemtype="https://schema.org/BlogPosting"
-  >
-    <!-- Article Header -->
-    <header class="mb-8 space-y-4">
-      <!-- Tags -->
-      <ul class="flex flex-wrap gap-2 list-none p-0" aria-label={t(lang, 'blog.tags')}>
-        {data.tags.map((tag) => (
-          <li><Tag label={tag} variant="accent" /></li>
-        ))}
-      </ul>
-
-      <!-- Title -->
-      <h1
-        class="text-4xl font-display font-bold leading-tight text-ink-900 dark:text-slate-100 sm:text-5xl lg:text-6xl"
-        itemprop="headline"
-      >
-        {data.title}
-      </h1>
-
-      <!-- Subtitle/Description -->
-      <p
-        class="text-lg text-slate-600 dark:text-slate-300 sm:text-xl"
-        itemprop="description"
-      >
-        {data.description}
-      </p>
-
-      <!-- Metadata -->
-      <div class="flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-b border-slate-200 dark:border-slate-700 py-4">
-        <DateDisplay date={data.publishDate} showIcon={true} lang={lang} />
-
-        <span class="text-slate-400" aria-hidden="true">•</span>
-
-        <ReadingTime text={readingTime.text} label={t(lang, 'blog.readingTime.label')} />
-
-        {data.updatedDate && (
-          <>
-            <span class="text-slate-400" aria-hidden="true">•</span>
-            <time
-              datetime={formatDateISO(data.updatedDate)}
-              class="text-sm text-slate-500"
-            >
-              {t(lang, 'blog.updated')} {formatDate(data.updatedDate, 'es-ES')}
-            </time>
-          </>
-        )}
-      </div>
-
-      {data.canonicalUrl && data.canonicalSource && (
-        <RepublishedNotice
-          lang={lang}
-          sourceUrl={data.canonicalUrl}
-          sourceName={data.canonicalSource}
-        />
-      )}
-    </header>
-
-    <!-- Article Content -->
-    <div
-      class="prose prose-slate dark:prose-invert max-w-none prose-headings:font-semibold prose-headings:tracking-tight prose-a:text-blue-600 dark:prose-a:text-blue-400 hover:prose-a:text-blue-700 dark:hover:prose-a:text-blue-300 prose-img:rounded-lg prose-img:max-h-[600px] prose-img:w-auto prose-img:mx-auto prose-img:object-contain"
-      itemprop="articleBody"
-      id="article-content"
-      data-code-block-label={t(lang, 'blog.codeBlock')}
+    <article
+      class="blog-page relative"
+      itemscope
+      itemtype="https://schema.org/BlogPosting"
     >
-      <Content />
-    </div>
-
-    <CodeBlockEnhancer lang={lang} />
-
-    <!-- Article Footer -->
-    <footer class="mt-12 border-t border-slate-200 dark:border-slate-700 pt-8">
-      <div class="flex items-center justify-between">
-        <!-- Author Info -->
-        <div class="flex items-center gap-3">
-          {data.author.avatar ? (
-            <img
-              src={data.author.avatar}
-              alt={`${data.author.name} avatar`}
-              class="h-12 w-12 rounded-full object-cover"
-            />
-          ) : (
-            <div class="h-12 w-12 rounded-full bg-gradient-to-br from-blue-600 to-purple-600 flex items-center justify-center text-white font-bold text-lg">
-              {data.author.name.split(' ').map(n => n[0]).join('')}
-            </div>
-          )}
-          <div>
-            <p class="font-medium text-ink-900 dark:text-slate-100">
-              {data.author.url ? (
-                <a href={data.author.url} class="hover:text-blue-600">
-                  {data.author.name}
-                </a>
-              ) : (
-                data.author.name
-              )}
-            </p>
-            <p class="text-sm text-slate-600">
-              {t(lang, 'blog.publishedOn')} <DateDisplay date={data.publishDate} lang={lang} />
-            </p>
-          </div>
+      <!-- Cinematic header -->
+      <header class="relative flex min-h-[80vh] items-center justify-center px-6 pb-16 pt-32 text-center">
+        <div aria-hidden="true" class="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+          <div class="absolute left-1/2 top-1/2 hidden h-[40rem] w-[40rem] -translate-x-1/2 -translate-y-1/2 rounded-full bg-gradient-conic from-accent-violet/30 via-accent-blue/20 to-accent-sky/30 blur-[120px] dark:block"></div>
         </div>
 
-        <!-- Back to Blog Link -->
-        <Button href="/blog" tone="blue">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke-width="2"
-            stroke="currentColor"
-            class="h-4 w-4 transition-transform group-hover:-translate-x-0.5"
-            aria-hidden="true"
-          >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
-          </svg>
-          <span>{t(lang, 'blog.backToBlog')}</span>
-        </Button>
-      </div>
-    </footer>
+        <div class="mx-auto max-w-3xl">
+          <ul class="flex flex-wrap justify-center gap-2 list-none p-0" aria-label={t(lang, 'blog.tags')}>
+            {data.tags.map((tag) => (
+              <li><Tag label={tag} variant="accent" /></li>
+            ))}
+          </ul>
 
-    <!-- Hidden Schema.org metadata -->
-    <meta itemprop="datePublished" content={data.publishDate.toISOString()} />
-    {data.updatedDate && (
-      <meta itemprop="dateModified" content={data.updatedDate.toISOString()} />
-    )}
-    <meta itemprop="author" content={data.author.name} />
-  </article>
+          <h1
+            class="mt-8 font-display text-5xl font-black leading-tight tracking-tight text-ink-900 dark:text-slate-50 sm:text-6xl lg:text-7xl"
+            itemprop="headline"
+          >
+            {data.title}
+          </h1>
+
+          <p
+            class="mx-auto mt-6 max-w-2xl text-base leading-relaxed text-slate-600 dark:text-slate-400 sm:text-lg"
+            itemprop="description"
+          >
+            {data.description}
+          </p>
+
+          <div class="mt-10 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 font-mono text-[11px] uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+            <DateDisplay date={data.publishDate} showIcon={true} lang={lang} />
+            <span aria-hidden="true">·</span>
+            <ReadingTime text={readingTime.text} label={t(lang, 'blog.readingTime.label')} />
+            {data.updatedDate && (
+              <>
+                <span aria-hidden="true">·</span>
+                <time
+                  datetime={formatDateISO(data.updatedDate)}
+                  class="normal-case tracking-normal text-xs text-slate-500"
+                >
+                  {t(lang, 'blog.updated')} {formatDate(data.updatedDate, 'es-ES')}
+                </time>
+              </>
+            )}
+          </div>
+        </div>
+      </header>
+
+      {data.canonicalUrl && data.canonicalSource && (
+        <div class="mx-auto max-w-3xl px-6 pb-8">
+          <RepublishedNotice
+            lang={lang}
+            sourceUrl={data.canonicalUrl}
+            sourceName={data.canonicalSource}
+          />
+        </div>
+      )}
+
+      <!-- Article body -->
+      <div class="mx-auto max-w-screen-xl px-6 pb-2 sm:px-7 md:px-8 md:pb-4 lg:px-20">
+        <div
+          class="prose prose-slate dark:prose-invert max-w-none prose-headings:font-semibold prose-headings:tracking-tight prose-a:text-blue-600 dark:prose-a:text-blue-400 hover:prose-a:text-blue-700 dark:hover:prose-a:text-blue-300 prose-img:rounded-lg prose-img:max-h-[600px] prose-img:w-auto prose-img:mx-auto prose-img:object-contain"
+          itemprop="articleBody"
+          id="article-content"
+          data-code-block-label={t(lang, 'blog.codeBlock')}
+        >
+          <Content />
+        </div>
+
+        <CodeBlockEnhancer lang={lang} />
+
+        <!-- Mini outro -->
+        <footer class="mt-24 border-t border-white/10 pt-12">
+          <div class="flex flex-col items-center gap-6">
+            <p class="font-mono text-[10px] uppercase tracking-[0.3em] text-secondary dark:text-accent-blue">
+              // {t(lang, 'blog.backToBlog').toLowerCase()}
+            </p>
+            <Button href="/blog" tone="violet" variant="ghost">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="2"
+                stroke="currentColor"
+                class="h-4 w-4 transition-transform group-hover:-translate-x-0.5"
+                aria-hidden="true"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
+              </svg>
+              <span>{t(lang, 'blog.backToBlog')}</span>
+            </Button>
+          </div>
+        </footer>
+      </div>
+
+      <!-- Hidden Schema.org metadata -->
+      <meta itemprop="datePublished" content={data.publishDate.toISOString()} />
+      {data.updatedDate && (
+        <meta itemprop="dateModified" content={data.updatedDate.toISOString()} />
+      )}
+      <meta itemprop="author" content={data.author.name} />
+    </article>
   </div>
 </Layout>
 
 <style is:global>
-  /**
-   * Page-specific prose tweaks on top of @tailwindcss/typography.
-   * Code block styling lives in CodeBlockEnhancer.
-   */
-
   .prose h2 {
     @apply mt-12 mb-4;
   }

--- a/src/pages/blog/[page].astro
+++ b/src/pages/blog/[page].astro
@@ -3,12 +3,13 @@ import { getCollection } from 'astro:content';
 import { sortPostsByDate, filterDrafts } from '@/lib/blog';
 import BlogContent from '@/components/blog/BlogContent.astro';
 
+const PAGE_SIZE = 6;
+
 export async function getStaticPaths() {
   const PAGE_SIZE = 6;
   const all = await getCollection('blog');
   const allPosts = sortPostsByDate(filterDrafts(all)).filter((p) => p.id.startsWith('es/'));
   const totalPages = Math.ceil(allPosts.length / PAGE_SIZE) || 1;
-  const totalPosts = allPosts.length;
 
   return Array.from({ length: Math.max(0, totalPages - 1) }, (_, idx) => {
     const currentPage = idx + 2;
@@ -19,7 +20,6 @@ export async function getStaticPaths() {
         posts: allPosts.slice(start, start + PAGE_SIZE),
         currentPage,
         totalPages,
-        firstPostNumber: totalPosts - start,
         prevUrl: currentPage === 2 ? '/blog' : `/blog/${currentPage - 1}`,
         nextUrl: currentPage < totalPages ? `/blog/${currentPage + 1}` : undefined,
       },
@@ -27,16 +27,13 @@ export async function getStaticPaths() {
   });
 }
 
-interface Props {
-  posts: any[];
-  currentPage: number;
-  totalPages: number;
-  firstPostNumber: number;
-  prevUrl?: string;
-  nextUrl?: string;
-}
+const { posts, currentPage, totalPages, prevUrl, nextUrl } = Astro.props;
 
-const { posts, currentPage, totalPages, firstPostNumber, prevUrl, nextUrl } = Astro.props;
+// Computed outside getStaticPaths to avoid serialization issues
+const allForCount = await getCollection('blog');
+const totalPosts = sortPostsByDate(filterDrafts(allForCount))
+  .filter((p) => p.id.startsWith('es/')).length;
+const firstPostNumber = totalPosts - (currentPage - 1) * PAGE_SIZE;
 
 const alternateUrl = `https://www.aitorevi.dev/en/blog/${currentPage}`;
 ---

--- a/src/pages/blog/[page].astro
+++ b/src/pages/blog/[page].astro
@@ -8,6 +8,7 @@ export async function getStaticPaths() {
   const all = await getCollection('blog');
   const allPosts = sortPostsByDate(filterDrafts(all)).filter((p) => p.id.startsWith('es/'));
   const totalPages = Math.ceil(allPosts.length / PAGE_SIZE) || 1;
+  const totalPosts = allPosts.length;
 
   return Array.from({ length: Math.max(0, totalPages - 1) }, (_, idx) => {
     const currentPage = idx + 2;
@@ -18,8 +19,7 @@ export async function getStaticPaths() {
         posts: allPosts.slice(start, start + PAGE_SIZE),
         currentPage,
         totalPages,
-        totalPosts: allPosts.length,
-        pageOffset: start,
+        firstPostNumber: totalPosts - start,
         prevUrl: currentPage === 2 ? '/blog' : `/blog/${currentPage - 1}`,
         nextUrl: currentPage < totalPages ? `/blog/${currentPage + 1}` : undefined,
       },
@@ -27,7 +27,16 @@ export async function getStaticPaths() {
   });
 }
 
-const { posts, currentPage, totalPages, totalPosts, pageOffset, prevUrl, nextUrl } = Astro.props;
+interface Props {
+  posts: any[];
+  currentPage: number;
+  totalPages: number;
+  firstPostNumber: number;
+  prevUrl?: string;
+  nextUrl?: string;
+}
+
+const { posts, currentPage, totalPages, firstPostNumber, prevUrl, nextUrl } = Astro.props;
 
 const alternateUrl = `https://www.aitorevi.dev/en/blog/${currentPage}`;
 ---
@@ -37,8 +46,7 @@ const alternateUrl = `https://www.aitorevi.dev/en/blog/${currentPage}`;
   posts={posts}
   currentPage={currentPage}
   totalPages={totalPages}
-  totalPosts={totalPosts}
-  pageOffset={pageOffset}
+  firstPostNumber={firstPostNumber}
   prevUrl={prevUrl}
   nextUrl={nextUrl}
   alternateUrl={alternateUrl}

--- a/src/pages/blog/[page].astro
+++ b/src/pages/blog/[page].astro
@@ -1,0 +1,42 @@
+---
+import { getCollection } from 'astro:content';
+import { sortPostsByDate, filterDrafts } from '@/lib/blog';
+import BlogContent from '@/components/blog/BlogContent.astro';
+
+const PAGE_SIZE = 6;
+
+export async function getStaticPaths() {
+  const all = await getCollection('blog');
+  const allPosts = sortPostsByDate(filterDrafts(all)).filter((p) => p.id.startsWith('es/'));
+  const totalPages = Math.ceil(allPosts.length / PAGE_SIZE) || 1;
+
+  return Array.from({ length: Math.max(0, totalPages - 1) }, (_, idx) => {
+    const currentPage = idx + 2;
+    const start = (currentPage - 1) * PAGE_SIZE;
+    return {
+      params: { page: String(currentPage) },
+      props: {
+        posts: allPosts.slice(start, start + PAGE_SIZE),
+        currentPage,
+        totalPages,
+        prevUrl: currentPage === 2 ? '/blog' : `/blog/${currentPage - 1}`,
+        nextUrl: currentPage < totalPages ? `/blog/${currentPage + 1}` : undefined,
+      },
+    };
+  });
+}
+
+const { posts, currentPage, totalPages, prevUrl, nextUrl } = Astro.props;
+
+const alternateUrl = `https://www.aitorevi.dev/en/blog/${currentPage}`;
+---
+
+<BlogContent
+  lang="es"
+  posts={posts}
+  currentPage={currentPage}
+  totalPages={totalPages}
+  prevUrl={prevUrl}
+  nextUrl={nextUrl}
+  alternateUrl={alternateUrl}
+/>

--- a/src/pages/blog/[page].astro
+++ b/src/pages/blog/[page].astro
@@ -18,6 +18,8 @@ export async function getStaticPaths() {
         posts: allPosts.slice(start, start + PAGE_SIZE),
         currentPage,
         totalPages,
+        totalPosts: allPosts.length,
+        pageOffset: start,
         prevUrl: currentPage === 2 ? '/blog' : `/blog/${currentPage - 1}`,
         nextUrl: currentPage < totalPages ? `/blog/${currentPage + 1}` : undefined,
       },
@@ -25,7 +27,7 @@ export async function getStaticPaths() {
   });
 }
 
-const { posts, currentPage, totalPages, prevUrl, nextUrl } = Astro.props;
+const { posts, currentPage, totalPages, totalPosts, pageOffset, prevUrl, nextUrl } = Astro.props;
 
 const alternateUrl = `https://www.aitorevi.dev/en/blog/${currentPage}`;
 ---
@@ -35,6 +37,8 @@ const alternateUrl = `https://www.aitorevi.dev/en/blog/${currentPage}`;
   posts={posts}
   currentPage={currentPage}
   totalPages={totalPages}
+  totalPosts={totalPosts}
+  pageOffset={pageOffset}
   prevUrl={prevUrl}
   nextUrl={nextUrl}
   alternateUrl={alternateUrl}

--- a/src/pages/blog/[page].astro
+++ b/src/pages/blog/[page].astro
@@ -3,9 +3,8 @@ import { getCollection } from 'astro:content';
 import { sortPostsByDate, filterDrafts } from '@/lib/blog';
 import BlogContent from '@/components/blog/BlogContent.astro';
 
-const PAGE_SIZE = 6;
-
 export async function getStaticPaths() {
+  const PAGE_SIZE = 6;
   const all = await getCollection('blog');
   const allPosts = sortPostsByDate(filterDrafts(all)).filter((p) => p.id.startsWith('es/'));
   const totalPages = Math.ceil(allPosts.length / PAGE_SIZE) || 1;

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -18,5 +18,5 @@ const posts = allPosts.slice(0, PAGE_SIZE);
   totalPages={totalPages}
   firstPostNumber={allPosts.length}
   nextUrl={totalPages > 1 ? '/blog/2' : undefined}
-  alternateUrl="https://www.aitorevi.dev/en/blog"
+  alternateUrl="https://www.aitorevi.dev/en/blog/"
 />

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -16,6 +16,8 @@ const posts = allPosts.slice(0, PAGE_SIZE);
   posts={posts}
   currentPage={1}
   totalPages={totalPages}
+  totalPosts={allPosts.length}
+  pageOffset={0}
   nextUrl={totalPages > 1 ? '/blog/2' : undefined}
   alternateUrl="https://www.aitorevi.dev/en/blog"
 />

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -16,8 +16,7 @@ const posts = allPosts.slice(0, PAGE_SIZE);
   posts={posts}
   currentPage={1}
   totalPages={totalPages}
-  totalPosts={allPosts.length}
-  pageOffset={0}
+  firstPostNumber={allPosts.length}
   nextUrl={totalPages > 1 ? '/blog/2' : undefined}
   alternateUrl="https://www.aitorevi.dev/en/blog"
 />

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,4 +1,21 @@
 ---
+import { getCollection } from 'astro:content';
+import { sortPostsByDate, filterDrafts } from '@/lib/blog';
 import BlogContent from '@/components/blog/BlogContent.astro';
+
+const PAGE_SIZE = 6;
+
+const all = await getCollection('blog');
+const allPosts = sortPostsByDate(filterDrafts(all)).filter((p) => p.id.startsWith('es/'));
+const totalPages = Math.ceil(allPosts.length / PAGE_SIZE) || 1;
+const posts = allPosts.slice(0, PAGE_SIZE);
 ---
-<BlogContent lang="es" />
+
+<BlogContent
+  lang="es"
+  posts={posts}
+  currentPage={1}
+  totalPages={totalPages}
+  nextUrl={totalPages > 1 ? '/blog/2' : undefined}
+  alternateUrl="https://www.aitorevi.dev/en/blog"
+/>

--- a/src/pages/en/blog/[...slug].astro
+++ b/src/pages/en/blog/[...slug].astro
@@ -107,121 +107,114 @@ const coverImageAbsolute = toAbsoluteUrl(coverImageUrl);
     })} />
   </Fragment>
 
-  <div class="relative min-h-screen">
-    <!-- Dark-mode-only dot field -->
+  <div class="blog-cinematic relative min-h-screen">
     <DotField position="fixed" />
 
-  <article
-    class="blog-page mx-auto max-w-screen-xl mt-16 md:mt-24 mb-2 md:mb-4 p-6 sm:p-7 md:p-8 lg:p-20"
-    itemscope
-    itemtype="https://schema.org/BlogPosting"
-  >
-    <header class="mb-8 space-y-4">
-      <ul class="flex flex-wrap gap-2 list-none p-0" aria-label={t(lang, 'blog.tags')}>
-        {data.tags.map((tag) => (
-          <li><Tag label={tag} variant="accent" /></li>
-        ))}
-      </ul>
-      <h1
-        class="text-4xl font-display font-bold leading-tight text-ink-900 dark:text-slate-100 sm:text-5xl lg:text-6xl"
-        itemprop="headline"
-      >
-        {data.title}
-      </h1>
-      <p
-        class="text-lg text-slate-600 dark:text-slate-300 sm:text-xl"
-        itemprop="description"
-      >
-        {data.description}
-      </p>
-      <div class="flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-b border-slate-200 dark:border-slate-700 py-4">
-        <DateDisplay date={data.publishDate} showIcon={true} lang="en" />
-        <span class="text-slate-400" aria-hidden="true">&bull;</span>
-        <ReadingTime text={readingTime.text} label={t(lang, 'blog.readingTime.label')} />
-        {data.updatedDate && (
-          <>
-            <span class="text-slate-400" aria-hidden="true">&bull;</span>
-            <time
-              datetime={formatDateISO(data.updatedDate)}
-              class="text-sm text-slate-500"
-            >
-              {t(lang, 'blog.updated')} {formatDate(data.updatedDate, 'en-US')}
-            </time>
-          </>
-        )}
-      </div>
-
-      {data.canonicalUrl && data.canonicalSource && (
-        <RepublishedNotice
-          lang={lang}
-          sourceUrl={data.canonicalUrl}
-          sourceName={data.canonicalSource}
-        />
-      )}
-    </header>
-
-    <div
-      class="prose prose-slate dark:prose-invert max-w-none prose-headings:font-semibold prose-headings:tracking-tight prose-a:text-blue-600 dark:prose-a:text-blue-400 hover:prose-a:text-blue-700 dark:hover:prose-a:text-blue-300 prose-img:rounded-lg prose-img:max-h-[600px] prose-img:w-auto prose-img:mx-auto prose-img:object-contain"
-      itemprop="articleBody"
-      id="article-content"
-      data-code-block-label={t(lang, 'blog.codeBlock')}
+    <article
+      class="blog-page relative"
+      itemscope
+      itemtype="https://schema.org/BlogPosting"
     >
-      <Content />
-    </div>
+      <header class="relative flex min-h-[80vh] items-center justify-center px-6 pb-16 pt-32 text-center">
+        <div aria-hidden="true" class="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+          <div class="absolute left-1/2 top-1/2 hidden h-[40rem] w-[40rem] -translate-x-1/2 -translate-y-1/2 rounded-full bg-gradient-conic from-accent-violet/30 via-accent-blue/20 to-accent-sky/30 blur-[120px] dark:block"></div>
+        </div>
 
-    <CodeBlockEnhancer lang={lang} />
+        <div class="mx-auto max-w-3xl">
+          <ul class="flex flex-wrap justify-center gap-2 list-none p-0" aria-label={t(lang, 'blog.tags')}>
+            {data.tags.map((tag) => (
+              <li><Tag label={tag} variant="accent" /></li>
+            ))}
+          </ul>
 
-    <footer class="mt-12 border-t border-slate-200 dark:border-slate-700 pt-8">
-      <div class="flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          {data.author.avatar ? (
-            <img
-              src={data.author.avatar}
-              alt={`${data.author.name} avatar`}
-              class="h-12 w-12 rounded-full object-cover"
-            />
-          ) : (
-            <div class="h-12 w-12 rounded-full bg-gradient-to-br from-blue-600 to-purple-600 flex items-center justify-center text-white font-bold text-lg">
-              {data.author.name.split(' ').map(n => n[0]).join('')}
-            </div>
-          )}
-          <div>
-            <p class="font-medium text-ink-900 dark:text-slate-100">
-              {data.author.url ? (
-                <a href={data.author.url} class="hover:text-blue-600">{data.author.name}</a>
-              ) : (
-                data.author.name
-              )}
-            </p>
-            <p class="text-sm text-slate-600">
-              {t(lang, 'blog.publishedOn')} <DateDisplay date={data.publishDate} lang="en" />
-            </p>
+          <h1
+            class="mt-8 font-display text-5xl font-black leading-tight tracking-tight text-ink-900 dark:text-slate-50 sm:text-6xl lg:text-7xl"
+            itemprop="headline"
+          >
+            {data.title}
+          </h1>
+
+          <p
+            class="mx-auto mt-6 max-w-2xl text-base leading-relaxed text-slate-600 dark:text-slate-400 sm:text-lg"
+            itemprop="description"
+          >
+            {data.description}
+          </p>
+
+          <div class="mt-10 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 font-mono text-[11px] uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+            <DateDisplay date={data.publishDate} showIcon={true} lang="en" />
+            <span aria-hidden="true">·</span>
+            <ReadingTime text={readingTime.text} label={t(lang, 'blog.readingTime.label')} />
+            {data.updatedDate && (
+              <>
+                <span aria-hidden="true">·</span>
+                <time
+                  datetime={formatDateISO(data.updatedDate)}
+                  class="normal-case tracking-normal text-xs text-slate-500"
+                >
+                  {t(lang, 'blog.updated')} {formatDate(data.updatedDate, 'en-US')}
+                </time>
+              </>
+            )}
           </div>
         </div>
-        <Button href="/en/blog" tone="blue">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="h-4 w-4 transition-transform group-hover:-translate-x-0.5" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
-          </svg>
-          <span>{t(lang, 'blog.backToBlog')}</span>
-        </Button>
-      </div>
-    </footer>
+      </header>
 
-    <meta itemprop="datePublished" content={data.publishDate.toISOString()} />
-    {data.updatedDate && (
-      <meta itemprop="dateModified" content={data.updatedDate.toISOString()} />
-    )}
-    <meta itemprop="author" content={data.author.name} />
-  </article>
+      {data.canonicalUrl && data.canonicalSource && (
+        <div class="mx-auto max-w-3xl px-6 pb-8">
+          <RepublishedNotice
+            lang={lang}
+            sourceUrl={data.canonicalUrl}
+            sourceName={data.canonicalSource}
+          />
+        </div>
+      )}
+
+      <div class="mx-auto max-w-screen-xl px-6 pb-2 sm:px-7 md:px-8 md:pb-4 lg:px-20">
+        <div
+          class="prose prose-slate dark:prose-invert max-w-none prose-headings:font-semibold prose-headings:tracking-tight prose-a:text-blue-600 dark:prose-a:text-blue-400 hover:prose-a:text-blue-700 dark:hover:prose-a:text-blue-300 prose-img:rounded-lg prose-img:max-h-[600px] prose-img:w-auto prose-img:mx-auto prose-img:object-contain"
+          itemprop="articleBody"
+          id="article-content"
+          data-code-block-label={t(lang, 'blog.codeBlock')}
+        >
+          <Content />
+        </div>
+
+        <CodeBlockEnhancer lang={lang} />
+
+        <footer class="mt-24 border-t border-white/10 pt-12">
+          <div class="flex flex-col items-center gap-6">
+            <p class="font-mono text-[10px] uppercase tracking-[0.3em] text-secondary dark:text-accent-blue">
+              // {t(lang, 'blog.backToBlog').toLowerCase()}
+            </p>
+            <Button href="/en/blog" tone="violet" variant="ghost">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="2"
+                stroke="currentColor"
+                class="h-4 w-4 transition-transform group-hover:-translate-x-0.5"
+                aria-hidden="true"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
+              </svg>
+              <span>{t(lang, 'blog.backToBlog')}</span>
+            </Button>
+          </div>
+        </footer>
+      </div>
+
+      <meta itemprop="datePublished" content={data.publishDate.toISOString()} />
+      {data.updatedDate && (
+        <meta itemprop="dateModified" content={data.updatedDate.toISOString()} />
+      )}
+      <meta itemprop="author" content={data.author.name} />
+    </article>
   </div>
 </Layout>
 
 <style is:global>
-  /**
-   * Page-specific prose tweaks on top of @tailwindcss/typography.
-   * Code block styling lives in CodeBlockEnhancer.
-   */
-
   .prose h2 {
     @apply mt-12 mb-4;
   }

--- a/src/pages/en/blog/[page].astro
+++ b/src/pages/en/blog/[page].astro
@@ -3,9 +3,8 @@ import { getCollection } from 'astro:content';
 import { sortPostsByDate, filterDrafts } from '@/lib/blog';
 import BlogContent from '@/components/blog/BlogContent.astro';
 
-const PAGE_SIZE = 6;
-
 export async function getStaticPaths() {
+  const PAGE_SIZE = 6;
   const all = await getCollection('blog');
   const allPosts = sortPostsByDate(filterDrafts(all)).filter((p) => p.id.startsWith('en/'));
   const totalPages = Math.ceil(allPosts.length / PAGE_SIZE) || 1;

--- a/src/pages/en/blog/[page].astro
+++ b/src/pages/en/blog/[page].astro
@@ -8,6 +8,7 @@ export async function getStaticPaths() {
   const all = await getCollection('blog');
   const allPosts = sortPostsByDate(filterDrafts(all)).filter((p) => p.id.startsWith('en/'));
   const totalPages = Math.ceil(allPosts.length / PAGE_SIZE) || 1;
+  const totalPosts = allPosts.length;
 
   return Array.from({ length: Math.max(0, totalPages - 1) }, (_, idx) => {
     const currentPage = idx + 2;
@@ -18,8 +19,7 @@ export async function getStaticPaths() {
         posts: allPosts.slice(start, start + PAGE_SIZE),
         currentPage,
         totalPages,
-        totalPosts: allPosts.length,
-        pageOffset: start,
+        firstPostNumber: totalPosts - start,
         prevUrl: currentPage === 2 ? '/en/blog' : `/en/blog/${currentPage - 1}`,
         nextUrl: currentPage < totalPages ? `/en/blog/${currentPage + 1}` : undefined,
       },
@@ -27,7 +27,16 @@ export async function getStaticPaths() {
   });
 }
 
-const { posts, currentPage, totalPages, totalPosts, pageOffset, prevUrl, nextUrl } = Astro.props;
+interface Props {
+  posts: any[];
+  currentPage: number;
+  totalPages: number;
+  firstPostNumber: number;
+  prevUrl?: string;
+  nextUrl?: string;
+}
+
+const { posts, currentPage, totalPages, firstPostNumber, prevUrl, nextUrl } = Astro.props;
 
 const alternateUrl = `https://www.aitorevi.dev/blog/${currentPage}`;
 ---
@@ -37,8 +46,7 @@ const alternateUrl = `https://www.aitorevi.dev/blog/${currentPage}`;
   posts={posts}
   currentPage={currentPage}
   totalPages={totalPages}
-  totalPosts={totalPosts}
-  pageOffset={pageOffset}
+  firstPostNumber={firstPostNumber}
   prevUrl={prevUrl}
   nextUrl={nextUrl}
   alternateUrl={alternateUrl}

--- a/src/pages/en/blog/[page].astro
+++ b/src/pages/en/blog/[page].astro
@@ -18,6 +18,8 @@ export async function getStaticPaths() {
         posts: allPosts.slice(start, start + PAGE_SIZE),
         currentPage,
         totalPages,
+        totalPosts: allPosts.length,
+        pageOffset: start,
         prevUrl: currentPage === 2 ? '/en/blog' : `/en/blog/${currentPage - 1}`,
         nextUrl: currentPage < totalPages ? `/en/blog/${currentPage + 1}` : undefined,
       },
@@ -25,7 +27,7 @@ export async function getStaticPaths() {
   });
 }
 
-const { posts, currentPage, totalPages, prevUrl, nextUrl } = Astro.props;
+const { posts, currentPage, totalPages, totalPosts, pageOffset, prevUrl, nextUrl } = Astro.props;
 
 const alternateUrl = `https://www.aitorevi.dev/blog/${currentPage}`;
 ---
@@ -35,6 +37,8 @@ const alternateUrl = `https://www.aitorevi.dev/blog/${currentPage}`;
   posts={posts}
   currentPage={currentPage}
   totalPages={totalPages}
+  totalPosts={totalPosts}
+  pageOffset={pageOffset}
   prevUrl={prevUrl}
   nextUrl={nextUrl}
   alternateUrl={alternateUrl}

--- a/src/pages/en/blog/[page].astro
+++ b/src/pages/en/blog/[page].astro
@@ -1,0 +1,42 @@
+---
+import { getCollection } from 'astro:content';
+import { sortPostsByDate, filterDrafts } from '@/lib/blog';
+import BlogContent from '@/components/blog/BlogContent.astro';
+
+const PAGE_SIZE = 6;
+
+export async function getStaticPaths() {
+  const all = await getCollection('blog');
+  const allPosts = sortPostsByDate(filterDrafts(all)).filter((p) => p.id.startsWith('en/'));
+  const totalPages = Math.ceil(allPosts.length / PAGE_SIZE) || 1;
+
+  return Array.from({ length: Math.max(0, totalPages - 1) }, (_, idx) => {
+    const currentPage = idx + 2;
+    const start = (currentPage - 1) * PAGE_SIZE;
+    return {
+      params: { page: String(currentPage) },
+      props: {
+        posts: allPosts.slice(start, start + PAGE_SIZE),
+        currentPage,
+        totalPages,
+        prevUrl: currentPage === 2 ? '/en/blog' : `/en/blog/${currentPage - 1}`,
+        nextUrl: currentPage < totalPages ? `/en/blog/${currentPage + 1}` : undefined,
+      },
+    };
+  });
+}
+
+const { posts, currentPage, totalPages, prevUrl, nextUrl } = Astro.props;
+
+const alternateUrl = `https://www.aitorevi.dev/blog/${currentPage}`;
+---
+
+<BlogContent
+  lang="en"
+  posts={posts}
+  currentPage={currentPage}
+  totalPages={totalPages}
+  prevUrl={prevUrl}
+  nextUrl={nextUrl}
+  alternateUrl={alternateUrl}
+/>

--- a/src/pages/en/blog/[page].astro
+++ b/src/pages/en/blog/[page].astro
@@ -3,12 +3,13 @@ import { getCollection } from 'astro:content';
 import { sortPostsByDate, filterDrafts } from '@/lib/blog';
 import BlogContent from '@/components/blog/BlogContent.astro';
 
+const PAGE_SIZE = 6;
+
 export async function getStaticPaths() {
   const PAGE_SIZE = 6;
   const all = await getCollection('blog');
   const allPosts = sortPostsByDate(filterDrafts(all)).filter((p) => p.id.startsWith('en/'));
   const totalPages = Math.ceil(allPosts.length / PAGE_SIZE) || 1;
-  const totalPosts = allPosts.length;
 
   return Array.from({ length: Math.max(0, totalPages - 1) }, (_, idx) => {
     const currentPage = idx + 2;
@@ -19,7 +20,6 @@ export async function getStaticPaths() {
         posts: allPosts.slice(start, start + PAGE_SIZE),
         currentPage,
         totalPages,
-        firstPostNumber: totalPosts - start,
         prevUrl: currentPage === 2 ? '/en/blog' : `/en/blog/${currentPage - 1}`,
         nextUrl: currentPage < totalPages ? `/en/blog/${currentPage + 1}` : undefined,
       },
@@ -27,16 +27,13 @@ export async function getStaticPaths() {
   });
 }
 
-interface Props {
-  posts: any[];
-  currentPage: number;
-  totalPages: number;
-  firstPostNumber: number;
-  prevUrl?: string;
-  nextUrl?: string;
-}
+const { posts, currentPage, totalPages, prevUrl, nextUrl } = Astro.props;
 
-const { posts, currentPage, totalPages, firstPostNumber, prevUrl, nextUrl } = Astro.props;
+// Computed outside getStaticPaths to avoid serialization issues
+const allForCount = await getCollection('blog');
+const totalPosts = sortPostsByDate(filterDrafts(allForCount))
+  .filter((p) => p.id.startsWith('en/')).length;
+const firstPostNumber = totalPosts - (currentPage - 1) * PAGE_SIZE;
 
 const alternateUrl = `https://www.aitorevi.dev/blog/${currentPage}`;
 ---

--- a/src/pages/en/blog/index.astro
+++ b/src/pages/en/blog/index.astro
@@ -16,8 +16,7 @@ const posts = allPosts.slice(0, PAGE_SIZE);
   posts={posts}
   currentPage={1}
   totalPages={totalPages}
-  totalPosts={allPosts.length}
-  pageOffset={0}
+  firstPostNumber={allPosts.length}
   nextUrl={totalPages > 1 ? '/en/blog/2' : undefined}
   alternateUrl="https://www.aitorevi.dev/blog"
 />

--- a/src/pages/en/blog/index.astro
+++ b/src/pages/en/blog/index.astro
@@ -18,5 +18,5 @@ const posts = allPosts.slice(0, PAGE_SIZE);
   totalPages={totalPages}
   firstPostNumber={allPosts.length}
   nextUrl={totalPages > 1 ? '/en/blog/2' : undefined}
-  alternateUrl="https://www.aitorevi.dev/blog"
+  alternateUrl="https://www.aitorevi.dev/blog/"
 />

--- a/src/pages/en/blog/index.astro
+++ b/src/pages/en/blog/index.astro
@@ -16,6 +16,8 @@ const posts = allPosts.slice(0, PAGE_SIZE);
   posts={posts}
   currentPage={1}
   totalPages={totalPages}
+  totalPosts={allPosts.length}
+  pageOffset={0}
   nextUrl={totalPages > 1 ? '/en/blog/2' : undefined}
   alternateUrl="https://www.aitorevi.dev/blog"
 />

--- a/src/pages/en/blog/index.astro
+++ b/src/pages/en/blog/index.astro
@@ -1,4 +1,21 @@
 ---
+import { getCollection } from 'astro:content';
+import { sortPostsByDate, filterDrafts } from '@/lib/blog';
 import BlogContent from '@/components/blog/BlogContent.astro';
+
+const PAGE_SIZE = 6;
+
+const all = await getCollection('blog');
+const allPosts = sortPostsByDate(filterDrafts(all)).filter((p) => p.id.startsWith('en/'));
+const totalPages = Math.ceil(allPosts.length / PAGE_SIZE) || 1;
+const posts = allPosts.slice(0, PAGE_SIZE);
 ---
-<BlogContent lang="en" />
+
+<BlogContent
+  lang="en"
+  posts={posts}
+  currentPage={1}
+  totalPages={totalPages}
+  nextUrl={totalPages > 1 ? '/en/blog/2' : undefined}
+  alternateUrl="https://www.aitorevi.dev/blog"
+/>

--- a/src/styles/retro.css
+++ b/src/styles/retro.css
@@ -500,3 +500,46 @@ html[data-retro] .blog-pagination span {
   color: var(--retro-text) !important;
 }
 
+/* Blog search */
+html[data-retro] .blog-search input {
+  font-family: var(--retro-font) !important;
+  border: 1px solid var(--retro-cyan) !important;
+  border-radius: 0 !important;
+  background: var(--retro-panel-deep) !important;
+  color: var(--retro-cyan-bright) !important;
+  transition: none !important;
+}
+html[data-retro] .blog-search input::placeholder {
+  color: var(--retro-panel-light) !important;
+}
+html[data-retro] .blog-search input:focus {
+  border-color: var(--retro-yellow) !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+html[data-retro] .blog-search-result {
+  font-family: var(--retro-font) !important;
+  border: 1px solid var(--retro-cyan) !important;
+  border-radius: 0 !important;
+  background: var(--retro-panel) !important;
+}
+html[data-retro] .blog-result-title {
+  color: var(--retro-yellow) !important;
+}
+html[data-retro] .blog-result-meta {
+  color: var(--retro-cyan-bright) !important;
+}
+html[data-retro] .blog-result-desc {
+  color: var(--retro-cream) !important;
+}
+html[data-retro] .blog-result-tag {
+  border: 1px solid var(--retro-cyan) !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  color: var(--retro-cyan) !important;
+}
+html[data-retro] .blog-search-empty {
+  font-family: var(--retro-font) !important;
+  color: var(--retro-cyan-bright) !important;
+}
+

--- a/src/styles/retro.css
+++ b/src/styles/retro.css
@@ -479,3 +479,24 @@ html[data-retro] .hero-scroll-line::after {
    .cinematic-mock and [data-cinematic-meta/visual] rules above already
    cover them. Nothing extra needed. */
 
+/* Blog pagination */
+html[data-retro] .blog-pagination {
+  font-family: var(--retro-font) !important;
+  letter-spacing: 0 !important;
+  text-transform: none !important;
+}
+html[data-retro] .blog-pagination a {
+  border: 1px solid var(--retro-cyan) !important;
+  border-radius: 0 !important;
+  padding: 0.25rem 0.75rem !important;
+  transition: none !important;
+  color: var(--retro-cyan) !important;
+}
+html[data-retro] .blog-pagination a:hover {
+  background: var(--retro-cyan) !important;
+  color: var(--retro-bg) !important;
+}
+html[data-retro] .blog-pagination span {
+  color: var(--retro-text) !important;
+}
+

--- a/tests/integration/build-output.test.ts
+++ b/tests/integration/build-output.test.ts
@@ -9,6 +9,8 @@ const exists = (path: string) => existsSync(join(dist, path, 'index.html'));
 describe('ES pages exist', () => {
   it('home', () => { expect(exists('')).toBe(true); });
   it('blog', () => { expect(exists('blog')).toBe(true); });
+  it('blog/2', () => { expect(exists('blog/2')).toBe(true); });
+  it('blog/3', () => { expect(exists('blog/3')).toBe(true); });
   it('cv', () => { expect(exists('cv')).toBe(true); });
   it('katas', () => { expect(exists('katas')).toBe(true); });
   it('work/aitorevi-dev', () => { expect(exists('work/aitorevi-dev')).toBe(true); });
@@ -20,6 +22,7 @@ describe('ES pages exist', () => {
 describe('EN pages exist', () => {
   it('en home', () => { expect(exists('en')).toBe(true); });
   it('en/blog', () => { expect(exists('en/blog')).toBe(true); });
+  it('en/blog/2', () => { expect(exists('en/blog/2')).toBe(true); });
   it('en/cv', () => { expect(exists('en/cv')).toBe(true); });
   it('en/katas', () => { expect(exists('en/katas')).toBe(true); });
   it('en/work/aitorevi-dev', () => { expect(exists('en/work/aitorevi-dev')).toBe(true); });

--- a/tests/unit/lib/blog.test.ts
+++ b/tests/unit/lib/blog.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calculateReadingTime, sortPostsByDate, filterDrafts } from '@/lib/blog';
+import { calculateReadingTime, sortPostsByDate, filterDrafts, filterPostsByQuery } from '@/lib/blog';
 
 describe('calculateReadingTime', () => {
   it('returns minimum 1 minute for empty content', () => {
@@ -88,5 +88,49 @@ describe('filterDrafts', () => {
       { data: {}, title: 'No flag' },
     ];
     expect(filterDrafts(posts, true)).toHaveLength(2);
+  });
+});
+
+describe('filterPostsByQuery', () => {
+  const posts = [
+    { title: 'TDD en TypeScript', description: 'Cómo aplicar TDD con vitest', tags: ['testing', 'typescript'] },
+    { title: 'Astro 6 Content Layer', description: 'Nuevo sistema de contenido', tags: ['astro', 'web'] },
+    { title: 'Clean Architecture', description: 'Separación de capas en backend', tags: ['arquitectura'] },
+  ];
+
+  it('returns all posts for empty query', () => {
+    expect(filterPostsByQuery(posts, '')).toHaveLength(3);
+  });
+
+  it('returns all posts for whitespace-only query', () => {
+    expect(filterPostsByQuery(posts, '   ')).toHaveLength(3);
+  });
+
+  it('matches by title (case-insensitive)', () => {
+    const result = filterPostsByQuery(posts, 'tdd');
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('TDD en TypeScript');
+  });
+
+  it('matches by description', () => {
+    const result = filterPostsByQuery(posts, 'vitest');
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('TDD en TypeScript');
+  });
+
+  it('matches by tag', () => {
+    const result = filterPostsByQuery(posts, 'astro');
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('Astro 6 Content Layer');
+  });
+
+  it('returns empty array when no matches', () => {
+    expect(filterPostsByQuery(posts, 'nada')).toHaveLength(0);
+  });
+
+  it('does not mutate the original array', () => {
+    const original = [...posts];
+    filterPostsByQuery(posts, 'tdd');
+    expect(posts).toEqual(original);
   });
 });


### PR DESCRIPTION
## Summary

Extiende el cinematic del listing al post individual.

- Header del post con orb conic-gradient (dark only), tags centrados, h1 enorme y metadata pill-row mono
- Footer reemplazado por mini-outro con Button ghost-violet hacia el listing
- Eliminado el bloque de author info visible (queda dentro del Schema.org)
- `RepublishedNotice` movido fuera del header

## Test plan

- [x] \`npx astro check\` → 0 errores
- [x] \`npm run test:unit -- --run\` → 161 tests OK
- [x] \`/blog/<slug>\` y \`/en/blog/<slug>\` responden 200 en dev
- [ ] Verificar visualmente posts ES + EN en dark/light/retro
- [ ] Verificar post con \`RepublishedNotice\` (crosspost) y post sin
- [ ] Verificar mobile (375px)

## Notas

PR base: \`blog-cinematic\` (#168). Decidir si A solo o A → master + B → A → master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)