### PR TITLE
feat(design): unified color system with CSS custom properties

### DIFF
--- a/src/components/blog/BlogContent.astro
+++ b/src/components/blog/BlogContent.astro
@@ -454,7 +454,15 @@ const outroTitle = lang === 'es'
       (entries) => { entries.forEach((e) => { if (e.isIntersecting) e.target.classList.add('is-active'); }); },
       { threshold: 0.18, rootMargin: '0px 0px -10% 0px' }
     );
-    sections.forEach((s) => observer.observe(s));
+    sections.forEach((s) => {
+      if (s.classList.contains('is-active')) return;
+      const rect = s.getBoundingClientRect();
+      if (rect.top < window.innerHeight * 0.9 && rect.bottom > 0) {
+        s.classList.add('is-active');
+      } else {
+        observer.observe(s);
+      }
+    });
   }
 
   // ── Blog search ─────────────────────────────────────────────────────────────

--- a/src/components/case-study/ImsContent.astro
+++ b/src/components/case-study/ImsContent.astro
@@ -32,7 +32,7 @@ const stack = {
     <section class="relative overflow-hidden py-24 sm:py-32">
       <div class="absolute inset-0 bg-gradient-to-b from-secondary/5 to-transparent dark:from-accent-blue/5" aria-hidden="true" />
       <div class="relative mx-auto max-w-5xl px-6 text-center">
-        <span class="inline-flex items-center rounded-full border border-secondary/20 bg-secondary/10 px-3 py-1 font-mono text-[10px] uppercase tracking-[0.15em] text-secondary dark:border-accent-violet/30 dark:bg-accent-violet/20 dark:text-accent-violet">
+        <span class="inline-flex items-center rounded-full border border-accent/20 bg-accent/10 px-3 py-1 font-mono text-[10px] uppercase tracking-[0.15em] text-accent">
           SaaS
         </span>
         <h1 class="mt-6 font-display text-4xl font-bold tracking-tight text-ink-900 dark:text-slate-200 sm:text-5xl">
@@ -86,7 +86,7 @@ const stack = {
               <ul class="mt-3 space-y-2">
                 {items.map((item) => (
                   <li class="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400">
-                    <span class="h-1.5 w-1.5 rounded-full bg-secondary/40 dark:bg-accent-violet/40" aria-hidden="true" />
+                    <span class="h-1.5 w-1.5 rounded-full bg-accent/40" aria-hidden="true" />
                     {item}
                   </li>
                 ))}

--- a/src/components/case-study/SelfContent.astro
+++ b/src/components/case-study/SelfContent.astro
@@ -151,16 +151,16 @@ const stack: Record<'frontend' | 'content' | 'infra' | 'testing', TechItem[]> = 
                     class:list={[
                       "relative shrink-0 rounded-full z-10",
                       isFirst
-                        ? "mt-[5px] h-4 w-4 border-2 border-secondary bg-secondary shadow-[0_0_10px_rgba(94,58,238,0.5)] dark:border-accent-violet dark:bg-accent-violet dark:shadow-[0_0_10px_rgba(167,139,250,0.5)]"
-                        : "mt-[5px] h-3 w-3 border-2 border-secondary/50 dark:border-accent-violet/40 bg-white dark:bg-ink-800",
+                        ? "mt-[5px] h-4 w-4 border-2 border-accent bg-accent shadow-glow-accent-dot"
+                        : "mt-[5px] h-3 w-3 border-2 border-accent/50 bg-white dark:bg-ink-800",
                     ]}
                   >
                     {isFirst && (
-                      <span class="absolute -inset-1 rounded-full bg-secondary/20 dark:bg-accent-violet/20 animate-pulse" aria-hidden="true" />
+                      <span class="absolute -inset-1 rounded-full bg-accent/20 animate-pulse" aria-hidden="true" />
                     )}
                   </div>
                   {!isLast && (
-                    <div class="w-0.5 flex-1 mb-[-5px] bg-secondary/25 dark:bg-accent-violet/30 shadow-[0_0_4px_rgba(94,58,238,0.15)] dark:shadow-[0_0_6px_rgba(167,139,250,0.25)]" aria-hidden="true" />
+                    <div class="w-0.5 flex-1 mb-[-5px] bg-accent/25 shadow-glow-accent-line" aria-hidden="true" />
                   )}
                 </div>
 

--- a/src/components/case-study/StackCategory.astro
+++ b/src/components/case-study/StackCategory.astro
@@ -22,7 +22,7 @@ const { label, items } = Astro.props;
   <h3 class="font-mono text-[10px] uppercase tracking-[0.3em] text-secondary dark:text-accent-blue">
     {label}
   </h3>
-  <div class="mt-4 h-px w-8 bg-secondary/40 dark:bg-accent-violet/40" aria-hidden="true" />
+  <div class="mt-4 h-px w-8 bg-accent/40" aria-hidden="true" />
   <ul class="mt-6 space-y-6">
     {items.map((item) => (
       <li
@@ -43,7 +43,7 @@ const { label, items } = Astro.props;
           />
         ) : (
           <span
-            class="flex h-8 w-8 items-center justify-center rounded-full border border-secondary/30 text-[11px] font-mono font-bold text-secondary dark:border-accent-violet/40 dark:text-accent-violet"
+            class="flex h-8 w-8 items-center justify-center rounded-full border border-accent/30 text-[11px] font-mono font-bold text-accent"
             aria-hidden="true"
           >
             {item.name.charAt(0)}

--- a/src/components/cv/CertificationCard.astro
+++ b/src/components/cv/CertificationCard.astro
@@ -7,12 +7,12 @@ interface Props {
 const { name, institution } = Astro.props;
 ---
 
-<div class="reveal-fade group relative rounded-xl p-4 border border-secondary/15 bg-slate-50/30 dark:border-accent-violet/20 dark:bg-ink-800 hover:border-secondary/40 dark:hover:border-accent-violet/40 hover:shadow-[0_0_12px_rgba(94,58,238,0.08)] dark:hover:shadow-[0_0_30px_rgba(167,139,250,0.15)] transition-all duration-300">
+<div class="reveal-fade group relative rounded-xl p-4 border border-accent/15 bg-slate-50/30 dark:bg-ink-800 hover:border-accent/40 hover:shadow-glow-accent-card-sm dark:hover:shadow-glow-accent-card-md transition-all duration-300">
   <div class="flex items-start gap-3">
-    <div class="mt-1 h-2.5 w-2.5 rounded-full bg-secondary/30 dark:bg-accent-violet/50 border border-secondary/40 dark:border-accent-violet/60 shrink-0 group-hover:dark:bg-accent-violet/70 group-hover:dark:border-accent-violet/80 transition-colors"></div>
+    <div class="mt-1 h-2.5 w-2.5 rounded-full bg-accent/30 border border-accent/40 shrink-0 group-hover:bg-accent/60 group-hover:border-accent/70 transition-colors"></div>
     <div>
       <h3 class="text-base font-display font-bold leading-snug tracking-tight dark:text-slate-100">{name}</h3>
-      <p class="text-secondary dark:text-accent-violet font-semibold text-sm mt-0.5">{institution}</p>
+      <p class="text-accent font-semibold text-sm mt-0.5">{institution}</p>
     </div>
   </div>
 </div>

--- a/src/components/cv/CvEducation.astro
+++ b/src/components/cv/CvEducation.astro
@@ -20,14 +20,14 @@ const { label, entries } = Astro.props;
       return (
         <div class="flex gap-3">
           <div class="flex flex-col items-center shrink-0 w-4">
-            <div class="mt-[9px] h-2.5 w-2.5 rounded-full bg-secondary/30 dark:bg-accent-violet/35 border border-secondary/40 dark:border-accent-violet/45 shrink-0 z-10"></div>
+            <div class="mt-[9px] h-2.5 w-2.5 rounded-full bg-accent/30 border border-accent/40 shrink-0 z-10"></div>
             {!isLast && (
-              <div class="flex-1 w-0 border-l-2 border-dotted border-secondary/20 dark:border-accent-violet/25"></div>
+              <div class="flex-1 w-0 border-l-2 border-dotted border-accent/20"></div>
             )}
           </div>
           <div class:list={["flex-1", isLast ? "pb-0" : "pb-5"]}>
             <h3 class="text-lg font-bold">{entry.degree}</h3>
-            <p class="text-secondary dark:text-accent-violet font-semibold text-sm">{entry.institution}</p>
+            <p class="text-accent font-semibold text-sm">{entry.institution}</p>
             <span class="text-xs text-slate-500 dark:text-slate-400 font-mono tracking-tight">{entry.period}</span>
           </div>
         </div>
@@ -48,16 +48,16 @@ const { label, entries } = Astro.props;
 
           {/* Timeline track */}
           <div class="flex flex-col items-center shrink-0 w-5">
-            <div class="reveal-scale mt-0.5 h-3 w-3 rounded-full border-2 border-secondary/50 dark:border-accent-violet/40 bg-white dark:bg-ink-800 shrink-0 z-10"></div>
+            <div class="reveal-scale mt-0.5 h-3 w-3 rounded-full border-2 border-accent/50 bg-white dark:bg-ink-800 shrink-0 z-10"></div>
             {!isLast && (
-              <div class="reveal-grow-y flex-1 w-0 border-l-2 border-dotted border-secondary/20 dark:border-accent-violet/25"></div>
+              <div class="reveal-grow-y flex-1 w-0 border-l-2 border-dotted border-accent/20"></div>
             )}
           </div>
 
           {/* Content column */}
           <div class:list={["reveal-right flex-1 pl-6", isLast ? "pb-0" : "pb-6"]}>
             <h3 class="text-lg font-bold">{entry.degree}</h3>
-            <p class="text-secondary dark:text-accent-violet font-semibold text-sm">{entry.institution}</p>
+            <p class="text-accent font-semibold text-sm">{entry.institution}</p>
           </div>
         </div>
       );

--- a/src/components/cv/CvExperience.astro
+++ b/src/components/cv/CvExperience.astro
@@ -58,22 +58,22 @@ const items = entries.flatMap((entry) =>
               class:list={[
                 "reveal-scale relative rounded-full shrink-0 z-10",
                 isFirst
-                  ? "h-4 w-4 border-2 border-secondary bg-secondary shadow-[0_0_10px_rgba(94,58,238,0.5)] dark:border-accent-violet dark:bg-accent-violet dark:shadow-[0_0_10px_rgba(167,139,250,0.5)]"
-                  : "mt-0.5 h-3 w-3 border-2 border-secondary/50 dark:border-accent-violet/40 bg-white dark:bg-ink-800"
+                  ? "h-4 w-4 border-2 border-accent bg-accent shadow-glow-accent-dot"
+                  : "mt-0.5 h-3 w-3 border-2 border-accent/50 bg-white dark:bg-ink-800"
               ]}
             >
               {isFirst && (
-                <span class="absolute -inset-1 rounded-full bg-secondary/20 dark:bg-accent-violet/20 animate-pulse"></span>
+                <span class="absolute -inset-1 rounded-full bg-accent/20 animate-pulse"></span>
               )}
             </div>
             {!isLast && (
-              <div class="reveal-grow-y w-0.5 flex-1 bg-secondary/25 dark:bg-accent-violet/30 shadow-[0_0_4px_rgba(94,58,238,0.15)] dark:shadow-[0_0_6px_rgba(167,139,250,0.25)]"></div>
+              <div class="reveal-grow-y w-0.5 flex-1 bg-accent/25 shadow-glow-accent-line"></div>
             )}
           </div>
 
           {/* Content column */}
           <div class:list={["reveal-right flex-1 pl-6", isLast ? "pb-0" : "pb-8"]}>
-            <span class="text-xs text-secondary dark:text-accent-violet font-semibold uppercase tracking-wider">{item.company} · {item.role}</span>
+            <span class="text-xs text-accent font-semibold uppercase tracking-wider">{item.company} · {item.role}</span>
             <strong class="block text-[0.95rem] leading-snug mt-0.5">{item.heading}</strong>
             {item.text && (
               <p class="text-sm text-slate-600 dark:text-slate-300 mt-1.5 leading-relaxed">{item.text}</p>

--- a/src/components/cv/CvExperienceItem.astro
+++ b/src/components/cv/CvExperienceItem.astro
@@ -19,21 +19,21 @@ const bullets = entry.bullets;
     <div class:list={[
       "relative mt-1 h-4 w-4 rounded-full border-2 shrink-0 z-10",
       isFirst
-        ? "border-secondary bg-secondary shadow-[0_0_10px_rgba(94,58,238,0.5)] dark:border-accent-violet dark:bg-accent-violet dark:shadow-[0_0_10px_rgba(167,139,250,0.5)]"
-        : "border-secondary/50 dark:border-accent-violet/40 bg-white dark:bg-ink-800"
+        ? "border-accent bg-accent shadow-glow-accent-dot"
+        : "border-accent/50 bg-white dark:bg-ink-800"
     ]}>
       {isFirst && (
-        <span class="absolute -inset-1 rounded-full bg-secondary/20 dark:bg-accent-violet/20 animate-pulse"></span>
+        <span class="absolute -inset-1 rounded-full bg-accent/20 animate-pulse"></span>
       )}
     </div>
-    <div class="w-0.5 flex-1 bg-secondary/25 dark:bg-accent-violet/30 shadow-[0_0_4px_rgba(94,58,238,0.15)] dark:shadow-[0_0_6px_rgba(167,139,250,0.25)]"></div>
+    <div class="w-0.5 flex-1 bg-accent/25 shadow-glow-accent-line"></div>
   </div>
   <!-- Company content -->
   <div class="flex-1 pb-4">
     <div class="flex flex-col md:flex-row md:items-baseline md:justify-between">
       <div>
-        <h3 class="text-xl font-bold leading-tight dark:text-accent-violet">{entry.company}</h3>
-        <p class="text-secondary dark:text-accent-violet font-semibold text-sm">{entry.role}</p>
+        <h3 class="text-xl font-bold leading-tight text-accent">{entry.company}</h3>
+        <p class="text-accent font-semibold text-sm">{entry.role}</p>
       </div>
       {entry.period && (
         <p class="text-xs text-slate-500 dark:text-slate-400 mt-1 md:mt-0 font-mono tracking-tight">{entry.period}</p>
@@ -52,11 +52,11 @@ const bullets = entry.bullets;
         <div class:list={[
           "mt-1 h-2.5 w-2.5 rounded-full shrink-0 z-10 transition-colors",
           isFirst && i === 0
-            ? "bg-secondary shadow-[0_0_6px_rgba(94,58,238,0.4)] dark:bg-accent-violet dark:shadow-[0_0_6px_rgba(167,139,250,0.4)]"
-            : "bg-secondary/30 dark:bg-accent-violet/35 border border-secondary/40 dark:border-accent-violet/45"
+            ? "bg-accent shadow-glow-accent-bullet"
+            : "bg-accent/30 border border-accent/40"
         ]}></div>
         {!isLastBullet && (
-          <div class="w-0.5 flex-1 bg-secondary/20 dark:bg-accent-violet/25 shadow-[0_0_4px_rgba(94,58,238,0.12)] dark:shadow-[0_0_6px_rgba(167,139,250,0.2)]"></div>
+          <div class="w-0.5 flex-1 bg-accent/20 shadow-glow-accent-line"></div>
         )}
       </div>
       <!-- Bullet content -->

--- a/src/components/cv/CvHeader.astro
+++ b/src/components/cv/CvHeader.astro
@@ -27,7 +27,7 @@ const contactHref = `${getLocalePath('/', lang)}#contact`;
   <p class="reveal-fade text-lg md:text-2xl font-display font-semibold tracking-tight mb-5">
     {contact.title.split(' | ').map((part, i, arr) => (
       <>
-        <span class="whitespace-nowrap text-secondary dark:text-accent-violet">{part}</span>
+        <span class="whitespace-nowrap text-accent">{part}</span>
         {i < arr.length - 1 && (
           <>
             <span class="hidden lg:inline text-quaternary/60 dark:text-slate-600 mx-2">/</span>

--- a/src/components/cv/CvSkillCategory.astro
+++ b/src/components/cv/CvSkillCategory.astro
@@ -9,9 +9,9 @@ interface Props {
 const { category } = Astro.props;
 ---
 
-<div class="reveal-fade group relative rounded-xl p-4 border border-secondary/15 bg-slate-50/30 dark:border-accent-violet/20 dark:bg-ink-800 hover:border-secondary/30 dark:hover:border-accent-violet/40 dark:hover:shadow-[0_0_30px_rgba(167,139,250,0.15)] transition-all duration-300">
+<div class="reveal-fade group relative rounded-xl p-4 border border-accent/15 bg-slate-50/30 dark:bg-ink-800 hover:border-accent/30 dark:hover:shadow-glow-accent-card-md transition-all duration-300">
   <div class="flex items-center gap-3 mb-3">
-    <div class="h-2.5 w-2.5 rounded-full bg-secondary/30 dark:bg-accent-violet/50 border border-secondary/40 dark:border-accent-violet/60 shrink-0 group-hover:dark:bg-accent-violet/70 group-hover:dark:border-accent-violet/80 transition-colors"></div>
+    <div class="h-2.5 w-2.5 rounded-full bg-accent/30 border border-accent/40 shrink-0 group-hover:bg-accent/60 group-hover:border-accent/70 transition-colors"></div>
     <h3 class="font-display font-bold text-base text-primary dark:text-slate-100 tracking-tight">{category.name}</h3>
   </div>
   <div class="flex flex-wrap gap-1.5">

--- a/src/components/home/LatestPosts.astro
+++ b/src/components/home/LatestPosts.astro
@@ -73,24 +73,24 @@ const itemSizingClass = isSingle
   /* Light-mode PostCard — crisp white card on slate-50 section background. */
   .home-post-wrapper article {
     background-color: #ffffff !important;
-    border-color: #e2e8f0 !important;
+    border-color: theme(colors.slate.200) !important;
   }
   .home-post-wrapper article h2 a {
     color: theme(colors.ink.700) !important;
   }
   .home-post-wrapper article h2 a:hover,
   .home-post-wrapper article h2 a:focus {
-    color: theme(colors.secondary) !important;
+    color: rgb(var(--color-accent)) !important;
   }
   .home-post-wrapper article p[itemprop='description'] {
-    color: rgba(71, 85, 105, 0.9) !important;
+    color: theme(colors.slate.600) !important;
   }
   .home-post-wrapper article footer {
-    border-top-color: #e2e8f0 !important;
+    border-top-color: theme(colors.slate.200) !important;
   }
   .home-post-wrapper article:hover {
-    border-color: rgba(94, 58, 238, 0.4) !important;
-    box-shadow: 0 20px 40px -20px rgba(94, 58, 238, 0.25) !important;
+    border-color: rgb(var(--color-accent) / 0.4) !important;
+    box-shadow: 0 20px 40px -20px rgb(var(--color-accent) / 0.25) !important;
   }
 
   /* Dark-mode PostCard — translucent glass card on ink-900. */
@@ -100,21 +100,21 @@ const itemSizingClass = isSingle
     backdrop-filter: blur(12px);
   }
   html.dark .home-post-wrapper article h2 a {
-    color: #e2e8f0 !important;
+    color: theme(colors.slate.200) !important;
   }
   html.dark .home-post-wrapper article h2 a:hover,
   html.dark .home-post-wrapper article h2 a:focus {
-    color: theme(colors.accent.violet) !important;
+    color: rgb(var(--color-accent)) !important;
   }
   html.dark .home-post-wrapper article p[itemprop='description'] {
-    color: rgba(148, 163, 184, 0.85) !important;
+    color: rgb(148 163 184 / 0.85) !important;
   }
   html.dark .home-post-wrapper article footer {
     border-top-color: rgba(255, 255, 255, 0.08) !important;
   }
   html.dark .home-post-wrapper article:hover {
-    border-color: rgba(96, 165, 250, 0.4) !important;
-    box-shadow: 0 0 60px rgba(96, 165, 250, 0.15) !important;
+    border-color: rgb(var(--color-accent-soft) / 0.4) !important;
+    box-shadow: 0 0 60px rgb(var(--color-accent-soft) / 0.15) !important;
   }
 </style>
 

--- a/src/components/home/Portfolio.astro
+++ b/src/components/home/Portfolio.astro
@@ -95,7 +95,7 @@ const itemBasisClass = projects.length === 4
               {t(lang, project.descKey)}
             </p>
 
-            <p class="mt-3 font-mono text-[11px] text-secondary dark:text-accent-violet">
+            <p class="mt-3 font-mono text-[11px] text-accent">
               {project.tech}
             </p>
           </div>

--- a/src/components/home/TestimonialCard.astro
+++ b/src/components/home/TestimonialCard.astro
@@ -19,7 +19,7 @@ const initials = author.split(' ').map((n: string) => n[0]).join('').slice(0, 2)
   tabindex={active ? 0 : -1}
   aria-labelledby={`testimonial-tab-${index}`}
   class:list={[
-    'carousel-slide relative flex flex-col overflow-hidden rounded-xl border border-secondary/15 bg-white px-7 py-8 dark:border-accent-violet/20 dark:bg-ink-800',
+    'carousel-slide relative flex flex-col overflow-hidden rounded-xl border border-accent/15 bg-white px-7 py-8 dark:bg-ink-800',
     active ? 'opacity-100' : 'opacity-0 pointer-events-none',
   ]}
   aria-hidden={!active ? 'true' : undefined}
@@ -27,12 +27,12 @@ const initials = author.split(' ').map((n: string) => n[0]).join('').slice(0, 2)
 >
   <!-- Top gradient overlay -->
   <div
-    class="pointer-events-none absolute inset-x-0 -top-20 h-40 bg-gradient-to-b from-secondary/10 to-transparent opacity-60 dark:from-accent-violet/10"
+    class="pointer-events-none absolute inset-x-0 -top-20 h-40 bg-gradient-to-b from-accent/10 to-transparent opacity-60"
     aria-hidden="true"
   />
   <!-- Decorative quote mark -->
   <span
-    class="pointer-events-none absolute right-5 top-2 select-none font-display text-7xl font-black leading-none text-secondary/10 dark:text-accent-violet/10"
+    class="pointer-events-none absolute right-5 top-2 select-none font-display text-7xl font-black leading-none text-accent/10"
     aria-hidden="true"
   >
     "
@@ -49,22 +49,22 @@ const initials = author.split(' ').map((n: string) => n[0]).join('').slice(0, 2)
       <a href={url} target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-3 transition-opacity duration-200 hover:opacity-80">
         {avatar
           ? <img src={avatar} alt={author} class="h-8 w-8 shrink-0 rounded-full object-cover" />
-          : <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-secondary/10 text-xs font-bold text-secondary dark:bg-accent-violet/15 dark:text-accent-violet" aria-hidden="true">{initials}</div>
+          : <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-accent/10 text-xs font-bold text-accent" aria-hidden="true">{initials}</div>
         }
         <div>
           <p class="text-sm font-semibold text-ink-900 dark:text-slate-100">{author}</p>
-          <p class="font-mono text-[11px] text-secondary dark:text-accent-violet whitespace-nowrap">{role}</p>
+          <p class="font-mono text-[11px] text-accent whitespace-nowrap">{role}</p>
         </div>
       </a>
     ) : (
       <div class="flex items-center gap-3">
         {avatar
           ? <img src={avatar} alt={author} class="h-8 w-8 shrink-0 rounded-full object-cover" />
-          : <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-secondary/10 text-xs font-bold text-secondary dark:bg-accent-violet/15 dark:text-accent-violet" aria-hidden="true">{initials}</div>
+          : <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-accent/10 text-xs font-bold text-accent" aria-hidden="true">{initials}</div>
         }
         <div>
           <p class="text-sm font-semibold text-ink-900 dark:text-slate-100">{author}</p>
-          <p class="font-mono text-[11px] text-secondary dark:text-accent-violet whitespace-nowrap">{role}</p>
+          <p class="font-mono text-[11px] text-accent whitespace-nowrap">{role}</p>
         </div>
       </div>
     )}

--- a/src/components/home/Testimonials.astro
+++ b/src/components/home/Testimonials.astro
@@ -167,7 +167,7 @@ const testimonials = lang === 'es'
   .dot-fill {
     position: absolute;
     inset: 0;
-    background-color: rgb(var(--color-secondary, 94 58 238));
+    background-color: rgb(var(--color-accent));
     transform: scaleX(0);
     transform-origin: left;
   }

--- a/src/components/nav/Nav.astro
+++ b/src/components/nav/Nav.astro
@@ -30,37 +30,37 @@ const workPath = getLocalePath('/work', lang);
         <nav aria-label={isEs ? 'Navegación principal' : 'Main navigation'} class="hidden md:flex items-center gap-8 mx-10 xl:mx-0 text-base font-mono">
             <a href={workPath}
                aria-current={isInWork ? 'page' : undefined}
-               class={`flex items-center cursor-pointer uppercase tracking-[0.15em] text-sm transition ease-linear delay-50 duration-200 ${isInWork ? 'text-secondary dark:text-accent-violet font-semibold' : 'text-inherit hover:text-secondary'}`}>
+               class={`flex items-center cursor-pointer uppercase tracking-[0.15em] text-sm transition ease-linear delay-50 duration-200 ${isInWork ? 'text-accent font-semibold' : 'text-inherit hover:text-accent'}`}>
                 {t(lang, 'nav.work')}
             </a>
             <a href={blogPath}
                aria-current={isInBlog ? 'page' : undefined}
-               class={`flex items-center cursor-pointer uppercase tracking-[0.15em] text-sm transition ease-linear delay-50 duration-200 ${isInBlog ? 'text-secondary dark:text-accent-violet font-semibold' : 'text-inherit hover:text-secondary'}`}>
+               class={`flex items-center cursor-pointer uppercase tracking-[0.15em] text-sm transition ease-linear delay-50 duration-200 ${isInBlog ? 'text-accent font-semibold' : 'text-inherit hover:text-accent'}`}>
                 {t(lang, 'nav.blog')}
             </a>
             <a href={cvPath}
                aria-current={isInCv ? 'page' : undefined}
-               class={`flex items-center cursor-pointer uppercase tracking-[0.15em] text-sm transition ease-linear delay-50 duration-200 ${isInCv ? 'text-secondary dark:text-accent-violet font-semibold' : 'text-inherit hover:text-secondary'}`}>
+               class={`flex items-center cursor-pointer uppercase tracking-[0.15em] text-sm transition ease-linear delay-50 duration-200 ${isInCv ? 'text-accent font-semibold' : 'text-inherit hover:text-accent'}`}>
                 {t(lang, 'nav.about')}
             </a>
             <div class="flex items-center gap-1 text-sm font-semibold" aria-label={isEs ? 'Seleccionar idioma' : 'Select language'}>
                 <a href={isEs ? currentPath : alternateUrl}
                    aria-current={isEs ? 'true' : undefined}
                    title={t(lang, 'nav.langEs')}
-                   class={`cursor-pointer transition ease-linear delay-50 duration-200 ${isEs ? 'text-secondary dark:text-accent-violet underline' : 'text-quaternary hover:text-secondary'}`}>
+                   class={`cursor-pointer transition ease-linear delay-50 duration-200 ${isEs ? 'text-accent underline' : 'text-quaternary hover:text-accent'}`}>
                     ES
                 </a>
                 <span class="text-quaternary" aria-hidden="true">|</span>
                 <a href={!isEs ? currentPath : alternateUrl}
                    aria-current={!isEs ? 'true' : undefined}
                    title={t(lang, 'nav.langEn')}
-                   class={`cursor-pointer transition ease-linear delay-50 duration-200 ${!isEs ? 'text-secondary dark:text-accent-violet underline' : 'text-quaternary hover:text-secondary'}`}>
+                   class={`cursor-pointer transition ease-linear delay-50 duration-200 ${!isEs ? 'text-accent underline' : 'text-quaternary hover:text-accent'}`}>
                     EN
                 </a>
             </div>
             <button
                 id="theme-toggle"
-                class="p-2 text-inherit hover:text-secondary transition-colors duration-200 cursor-pointer"
+                class="p-2 text-inherit hover:text-accent transition-colors duration-200 cursor-pointer"
                 aria-label={t(lang, 'nav.themeToggle')}
                 title={t(lang, 'nav.themeToggle')}
             >
@@ -77,7 +77,7 @@ const workPath = getLocalePath('/work', lang);
         <div class="flex md:hidden items-center gap-2 mx-6">
             <button
                 id="theme-toggle-mobile"
-                class="p-2 text-inherit hover:text-secondary transition-colors duration-200 cursor-pointer"
+                class="p-2 text-inherit hover:text-accent transition-colors duration-200 cursor-pointer"
                 aria-label={t(lang, 'nav.themeToggle')}
                 title={t(lang, 'nav.themeToggle')}
             >
@@ -90,7 +90,7 @@ const workPath = getLocalePath('/work', lang);
             </button>
             <button
                 id="hamburger-toggle"
-                class="p-2 text-inherit hover:text-secondary transition-colors duration-200 cursor-pointer"
+                class="p-2 text-inherit hover:text-accent transition-colors duration-200 cursor-pointer"
                 aria-label={isEs ? 'Abrir menú' : 'Toggle menu'}
                 aria-expanded="false"
                 aria-controls="mobile-menu"
@@ -112,31 +112,31 @@ const workPath = getLocalePath('/work', lang);
         <nav aria-label={isEs ? 'Menú móvil' : 'Mobile menu'} class="flex flex-col p-8 gap-6 text-lg text-center font-mono uppercase tracking-[0.15em]">
             <a href={workPath}
                aria-current={isInWork ? 'page' : undefined}
-               class={`cursor-pointer transition ease-linear delay-50 duration-200 ${isInWork ? 'text-secondary dark:text-accent-violet font-semibold' : 'text-inherit hover:text-secondary'}`}>
+               class={`cursor-pointer transition ease-linear delay-50 duration-200 ${isInWork ? 'text-accent font-semibold' : 'text-inherit hover:text-accent'}`}>
                 {t(lang, 'nav.work')}
             </a>
             <a href={blogPath}
                aria-current={isInBlog ? 'page' : undefined}
-               class={`cursor-pointer transition ease-linear delay-50 duration-200 ${isInBlog ? 'text-secondary dark:text-accent-violet font-semibold' : 'text-inherit hover:text-secondary'}`}>
+               class={`cursor-pointer transition ease-linear delay-50 duration-200 ${isInBlog ? 'text-accent font-semibold' : 'text-inherit hover:text-accent'}`}>
                 {t(lang, 'nav.blog')}
             </a>
             <a href={cvPath}
                aria-current={isInCv ? 'page' : undefined}
-               class={`cursor-pointer transition ease-linear delay-50 duration-200 ${isInCv ? 'text-secondary dark:text-accent-violet font-semibold' : 'text-inherit hover:text-secondary'}`}>
+               class={`cursor-pointer transition ease-linear delay-50 duration-200 ${isInCv ? 'text-accent font-semibold' : 'text-inherit hover:text-accent'}`}>
                 {t(lang, 'nav.about')}
             </a>
             <div class="flex items-center justify-center gap-1 text-sm font-semibold">
                 <a href={isEs ? currentPath : alternateUrl}
                    aria-current={isEs ? 'true' : undefined}
                    title={t(lang, 'nav.langEs')}
-                   class={`cursor-pointer transition ease-linear delay-50 duration-200 ${isEs ? 'text-secondary dark:text-accent-violet underline' : 'text-quaternary hover:text-secondary'}`}>
+                   class={`cursor-pointer transition ease-linear delay-50 duration-200 ${isEs ? 'text-accent underline' : 'text-quaternary hover:text-accent'}`}>
                     ES
                 </a>
                 <span class="text-quaternary" aria-hidden="true">|</span>
                 <a href={!isEs ? currentPath : alternateUrl}
                    aria-current={!isEs ? 'true' : undefined}
                    title={t(lang, 'nav.langEn')}
-                   class={`cursor-pointer transition ease-linear delay-50 duration-200 ${!isEs ? 'text-secondary dark:text-accent-violet underline' : 'text-quaternary hover:text-secondary'}`}>
+                   class={`cursor-pointer transition ease-linear delay-50 duration-200 ${!isEs ? 'text-accent underline' : 'text-quaternary hover:text-accent'}`}>
                     EN
                 </a>
             </div>

--- a/src/components/shared/EyebrowTag.astro
+++ b/src/components/shared/EyebrowTag.astro
@@ -9,7 +9,7 @@ const { label, class: className } = Astro.props;
 
 <span
   class:list={[
-    'inline-flex w-fit items-center rounded-full border border-secondary/20 bg-secondary/10 px-2.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.15em] text-secondary dark:border-accent-violet/30 dark:bg-accent-violet/20 dark:text-accent-violet',
+    'inline-flex w-fit items-center rounded-full border border-accent/20 bg-accent/10 px-2.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.15em] text-accent',
     className,
   ]}
 >

--- a/src/components/shared/StatCard.astro
+++ b/src/components/shared/StatCard.astro
@@ -12,7 +12,7 @@ const { value, label, suffix = '', tilt = false, class: className } = Astro.prop
 
 <div
   class:list={[
-    'group relative overflow-hidden rounded-xl border border-secondary/15 bg-slate-50/30 px-6 py-10 text-center transition-[border-color,box-shadow] duration-300 hover:border-secondary/40 hover:shadow-[0_0_12px_rgba(94,58,238,0.08)] dark:border-accent-violet/20 dark:bg-ink-800 dark:hover:border-accent-violet/40 dark:hover:shadow-[0_0_30px_rgba(167,139,250,0.15)]',
+    'group relative overflow-hidden rounded-xl border border-accent/15 bg-slate-50/30 px-6 py-10 text-center transition-[border-color,box-shadow] duration-300 hover:border-accent/40 hover:shadow-glow-accent-card-sm dark:bg-ink-800 dark:hover:shadow-glow-accent-card-md',
     className,
   ]}
   data-stat
@@ -21,7 +21,7 @@ const { value, label, suffix = '', tilt = false, class: className } = Astro.prop
   data-tilt-stat={tilt ? '' : undefined}
 >
   <div
-    class="pointer-events-none absolute inset-x-0 -top-20 h-40 bg-gradient-to-b from-secondary/10 to-transparent opacity-60 dark:from-accent-violet/10"
+    class="pointer-events-none absolute inset-x-0 -top-20 h-40 bg-gradient-to-b from-accent/10 to-transparent opacity-60"
     aria-hidden="true"
   />
   <div
@@ -31,7 +31,7 @@ const { value, label, suffix = '', tilt = false, class: className } = Astro.prop
   >
     {0}
   </div>
-  <div class="relative mt-3 font-mono text-[11px] uppercase tracking-[0.25em] text-secondary transition-colors dark:text-accent-violet group-hover:dark:text-accent-violet">
+  <div class="relative mt-3 font-mono text-[11px] uppercase tracking-[0.25em] text-accent transition-colors">
     {label}
   </div>
 </div>

--- a/src/components/shared/Tag.astro
+++ b/src/components/shared/Tag.astro
@@ -41,7 +41,7 @@ const variantStyles = {
   // OPCIÓN 1: "Soft Accent" - RECOMENDADA
   // Fondo morado suave con texto morado oscuro
   // Contraste AAA, hover con fondo más saturado
-  accent: 'bg-secondary/10 text-secondary border border-secondary/20 dark:bg-accent-violet/20 dark:text-accent-violet dark:border-accent-violet/30',
+  accent: 'bg-accent/10 text-accent border border-accent/20',
 
   // OPCIÓN 2: "Minimal Outlined" - Descomentar para probar
   // accent: 'bg-white border border-secondary text-secondary hover:bg-secondary hover:text-white',

--- a/src/components/work/WorkCinematic.astro
+++ b/src/components/work/WorkCinematic.astro
@@ -81,11 +81,11 @@ const projects = [
   },
 ];
 
-const accentMap: Record<string, { text: string; bg: string; ring: string; glow: string; buttonTone: ButtonTone }> = {
-  violet:  { text: 'text-accent-violet',  bg: 'bg-accent-violet',  ring: 'ring-accent-violet/40',  glow: 'from-accent-violet/30', buttonTone: 'violet' },
-  blue:    { text: 'text-accent-blue',    bg: 'bg-accent-blue',    ring: 'ring-accent-blue/40',    glow: 'from-accent-blue/30',   buttonTone: 'blue' },
-  emerald: { text: 'text-emerald-400',    bg: 'bg-emerald-400',    ring: 'ring-emerald-400/40',    glow: 'from-emerald-400/25',   buttonTone: 'blue' },
-  sky:     { text: 'text-accent-sky',     bg: 'bg-accent-sky',     ring: 'ring-accent-sky/40',     glow: 'from-accent-sky/25',    buttonTone: 'blue' },
+const accentMap: Record<string, { text: string; bg: string; ring: string; glow: string; buttonTone: ButtonTone; sectionVar: string }> = {
+  violet:  { text: 'text-accent-violet',  bg: 'bg-accent-violet',  ring: 'ring-accent-violet/40',  glow: 'from-accent-violet/30', buttonTone: 'violet', sectionVar: '--color-section-violet' },
+  blue:    { text: 'text-accent-blue',    bg: 'bg-accent-blue',    ring: 'ring-accent-blue/40',    glow: 'from-accent-blue/30',   buttonTone: 'blue',   sectionVar: '--color-section-blue' },
+  emerald: { text: 'text-emerald-400',    bg: 'bg-emerald-400',    ring: 'ring-emerald-400/40',    glow: 'from-emerald-400/25',   buttonTone: 'blue',   sectionVar: '--color-section-emerald' },
+  sky:     { text: 'text-accent-sky',     bg: 'bg-accent-sky',     ring: 'ring-accent-sky/40',     glow: 'from-accent-sky/25',    buttonTone: 'blue',   sectionVar: '--color-section-sky' },
 };
 
 const ctaLabel = lang === 'es' ? 'Ver caso' : 'View case';
@@ -133,7 +133,7 @@ const externalLabel = lang === 'es' ? 'Visitar sitio' : 'Visit site';
       <article
         class="cinematic-section relative flex min-h-screen items-center px-6 py-24 md:py-32"
         data-cinematic-section
-        style={`--cin-i:${i}`}
+        style={`--cin-i:${i}; --cin-hover:rgb(var(${accent.sectionVar}))`}
         aria-labelledby={`proj-${p.id}`}
       >
         <!-- Per-section ambient glow -->
@@ -163,7 +163,7 @@ const externalLabel = lang === 'es' ? 'Visitar sitio' : 'Visit site';
                   <a
                     href={p.href}
                     {...(p.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-                    class="hover:text-secondary dark:hover:text-accent-violet transition-colors duration-200 focus:outline-none focus-visible:underline"
+                    class="proj-title-link transition-colors duration-200 focus:outline-none focus-visible:underline"
                   >
                     {p.name}
                   </a>
@@ -384,6 +384,12 @@ const externalLabel = lang === 'es' ? 'Visitar sitio' : 'Visit site';
     opacity: 1;
   }
 
+  /* Per-section title hover — color comes from --cin-hover set on the article */
+  .cinematic-section .proj-title-link:hover,
+  .cinematic-section .proj-title-link:focus-visible {
+    color: var(--cin-hover);
+  }
+
   /* Mock scaffolding */
   .cinematic-mock {
     transform: perspective(1400px) rotateX(2deg) rotateY(-3deg);
@@ -471,7 +477,15 @@ const externalLabel = lang === 'es' ? 'Visitar sitio' : 'Visit site';
       { threshold: 0.18, rootMargin: '0px 0px -10% 0px' },
     );
 
-    sections.forEach((s) => observer.observe(s));
+    sections.forEach((s) => {
+      if (s.classList.contains('is-active')) return;
+      const rect = s.getBoundingClientRect();
+      if (rect.top < window.innerHeight * 0.9 && rect.bottom > 0) {
+        s.classList.add('is-active');
+      } else {
+        observer.observe(s);
+      }
+    });
   }
 
   setupCinematicReveal();

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,6 +7,7 @@ import Nav from "@/components/nav/Nav.astro";
 import Footer from "@/components/footer/Footer.astro";
 import { getLangFromUrl, getAlternateUrl, t } from '@/i18n/utils';
 import type { Lang } from '@/i18n/types';
+import '@/styles/tokens.css';
 import '@/styles/retro.css';
 
 interface Props {
@@ -129,7 +130,7 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `https://www.aitorevi.
 		<GoogleAnalytics />
 	</head>
 	<body
-		class="flex flex-col min-h-dvh bg-white dark:bg-[#0f1419] text-primary dark:text-[#f1f5f9] scrollbar scrollbar-thumb-primary scrollbar-w-2 scrollbar-corner-rounded-xl"
+		class="flex flex-col min-h-dvh bg-white dark:bg-page text-primary dark:text-fg scrollbar scrollbar-thumb-primary scrollbar-w-2 scrollbar-corner-rounded-xl"
 		data-bg={variant === 'default' ? undefined : variant}
 	>
 		<a
@@ -165,20 +166,20 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `https://www.aitorevi.
 	}
 
 	::-webkit-scrollbar-track {
-		background: rgba(33, 39, 55, .6);
+		background: rgb(var(--color-scrollbar-track) / 0.6);
 	}
 
 	::-webkit-scrollbar-track:hover {
-		background: rgba(33, 39, 55, .6);
+		background: rgb(var(--color-scrollbar-track) / 0.6);
 	}
 
 	::-webkit-scrollbar-thumb {
-		background: rgba(94, 58, 238);
+		background: rgb(var(--color-scrollbar-thumb));
 		border-radius: 0.25rem;
 	}
 
 	::-webkit-scrollbar-thumb:hover {
-		background: rgba(118, 85, 249);
+		background: rgb(var(--color-scrollbar-thumb-hover));
 		border-radius: 0.25rem;
 	}
 </style>

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,64 @@
+/*
+ * Design system tokens — CSS custom properties.
+ *
+ * These vars are consumed by Tailwind via tailwind.config.mjs using the
+ * `rgb(var(--X) / <alpha-value>)` pattern. The `.dark` overrides let a
+ * single Tailwind class (e.g. `text-accent`) adapt to both modes without
+ * needing `dark:` prefixes at the call site.
+ *
+ * Import order in Layout.astro: this file → retro.css (retro overrides
+ * some of these vars for the retro mode).
+ */
+
+:root {
+  /* ── Page background ──────────────────────────────────────────────── */
+  --color-bg: 255 255 255;        /* white */
+  --color-surface: 255 255 255;   /* card surface */
+
+  /* ── Text ─────────────────────────────────────────────────────────── */
+  --color-fg: 21 27 39;           /* primary #151b27 */
+  --color-fg-muted: 100 116 139;  /* slate-500 */
+  --color-fg-subtle: 148 163 184; /* slate-400 */
+
+  /* ── Accent (primary brand color) ────────────────────────────────── */
+  /* Light: secondary (#5e3aee). Dark: accent-violet (#a78bfa).         */
+  --color-accent: 94 58 238;
+
+  /* Secondary accent. Light: accent-violet. Dark: accent-blue.        */
+  --color-accent-soft: 167 139 250;
+
+  /* ── Scrollbar ────────────────────────────────────────────────────── */
+  --color-scrollbar-track: 33 39 55;
+  --color-scrollbar-thumb: 94 58 238;       /* secondary */
+  --color-scrollbar-thumb-hover: 118 85 249;
+
+  /* ── Glow shadows (reference --color-accent, auto-switch in dark) ── */
+  --shadow-glow-dot:      0 0 10px rgb(var(--color-accent) / 0.5);
+  --shadow-glow-bullet:   0 0 6px  rgb(var(--color-accent) / 0.4);
+  --shadow-glow-line:     0 0 4px  rgb(var(--color-accent) / 0.15);
+  --shadow-glow-card-sm:  0 0 12px rgb(var(--color-accent) / 0.08);
+  --shadow-glow-card-md:  0 0 30px rgb(var(--color-accent) / 0.15);
+}
+
+.dark {
+  /* ── Page background ──────────────────────────────────────────────── */
+  --color-bg: 15 20 25;           /* #0f1419 — body dark (unificado) */
+  --color-surface: 11 17 32;      /* ink-800 #0b1120 */
+
+  /* ── Text ─────────────────────────────────────────────────────────── */
+  --color-fg: 241 245 249;        /* slate-100 / #f1f5f9 */
+  --color-fg-muted: 148 163 184;  /* slate-400 */
+  --color-fg-subtle: 100 116 139; /* slate-500 */
+
+  /* ── Accent ───────────────────────────────────────────────────────── */
+  --color-accent: 167 139 250;    /* accent-violet #a78bfa */
+  --color-accent-soft: 96 165 250; /* accent-blue #60a5fa */
+
+  /* ── Scrollbar ────────────────────────────────────────────────────── */
+  --color-scrollbar-thumb: 167 139 250;       /* accent-violet */
+  --color-scrollbar-thumb-hover: 196 181 253; /* violet-300 */
+
+  /* ── Glow shadows — slightly stronger in dark (lighter accent) ────── */
+  --shadow-glow-line:    0 0 6px  rgb(var(--color-accent) / 0.25);
+  --shadow-glow-card-md: 0 0 30px rgb(var(--color-accent) / 0.15);
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -27,6 +27,12 @@
   /* Secondary accent. Light: accent-violet. Dark: accent-blue.        */
   --color-accent-soft: 167 139 250;
 
+  /* ── Section accent palette (cinematic sections, static across modes) ── */
+  --color-section-violet:  167 139 250;  /* #a78bfa */
+  --color-section-blue:     96 165 250;  /* #60a5fa */
+  --color-section-emerald:  52 211 153;  /* #34d399 */
+  --color-section-sky:      56 189 248;  /* #38bdf8 */
+
   /* ── Scrollbar ────────────────────────────────────────────────────── */
   --color-scrollbar-track: 33 39 55;
   --color-scrollbar-thumb: 94 58 238;       /* secondary */

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -5,29 +5,44 @@ export default {
 	theme: {
 		extend: {
 			colors: {
-				primary: '#151b27',
-				secondary: '#5e3aee',
-				tertiary: '#d0edf5',
+				// ── Semantic tokens (CSS var-driven, auto dark/light) ────────────
+				// accent.DEFAULT → text-accent, bg-accent, border-accent, etc.
+				// accent-violet / accent-blue / accent-sky kept as raw aliases.
+				accent: {
+					DEFAULT: 'rgb(var(--color-accent) / <alpha-value>)',
+					soft:    'rgb(var(--color-accent-soft) / <alpha-value>)',
+					violet: '#a78bfa',
+					blue:   '#60a5fa',
+					sky:    '#38bdf8',
+				},
+				// Page background token (bg-page switches light/dark automatically)
+				page: 'rgb(var(--color-bg) / <alpha-value>)',
+				// Foreground text token (text-fg switches light/dark automatically)
+				fg:   'rgb(var(--color-fg) / <alpha-value>)',
+
+				// ── Raw tokens (kept for backward-compat) ────────────────────────
+				primary:    '#151b27',
+				secondary:  '#5e3aee',
+				tertiary:   '#d0edf5',   // referenced in retro.css
 				quaternary: '#aeb2bb',
-				baseLight: '#f1faff',
-				blueLight: '#7ad5f3',
-				grayLight: '#f9f9fc',
-				// Home redesign palette — dark slate base + violet accents
+				grayLight:  '#f9f9fc',   // used in Tag.astro default variant
+				baseLight:  '#f1faff',   // referenced in retro.css
 				ink: {
 					900: '#020617',
 					800: '#0b1120',
 					700: '#0f172a',
-					600: '#111827',
-				},
-				accent: {
-					blue: '#60a5fa',
-					violet: '#a78bfa',
-					sky: '#38bdf8',
 				},
 				code: {
-					bg: '#1a1f2e',     // dark code block / blockquote background
-					header: '#1e2533', // dark code block title bar
+					bg: '#1a1f2e',       // used in RepublishedNotice.astro
 				},
+			},
+			boxShadow: {
+				// Glow utilities — reference CSS var so they switch with dark mode
+				'glow-accent-dot':    'var(--shadow-glow-dot)',
+				'glow-accent-bullet': 'var(--shadow-glow-bullet)',
+				'glow-accent-line':   'var(--shadow-glow-line)',
+				'glow-accent-card-sm':'var(--shadow-glow-card-sm)',
+				'glow-accent-card-md':'var(--shadow-glow-card-md)',
 			},
 			backgroundImage: {
 				'home-radial': 'radial-gradient(ellipse at 30% 20%, #0f172a 0%, #020617 55%, #000 100%)',

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -33,7 +33,8 @@ export default {
 					700: '#0f172a',
 				},
 				code: {
-					bg: '#1a1f2e',       // used in RepublishedNotice.astro
+					bg:     '#1a1f2e',   // used in RepublishedNotice.astro + CodeBlockEnhancer
+					header: '#1e2533',   // used in CodeBlockEnhancer.astro (title bar)
 				},
 			},
 			boxShadow: {


### PR DESCRIPTION
## Summary

- Introduce `src/styles/tokens.css` with semantic CSS vars (`--color-accent`, `--color-fg`, `--color-bg`, glow shadows, section accents) that auto-switch between light and dark mode
- Extend Tailwind config with `accent`, `page`, and `fg` semantic tokens so a single class like `text-accent` or `bg-page` adapts to both modes without `dark:` prefixes at call sites
- Migrate Nav, CV timeline, home section (LatestPosts, Testimonials, StatCard), and shared components away from compound `text-secondary dark:text-accent-violet` patterns
- Add `--color-section-*` vars for cinematic section accent palette (work + blog)
- Fix per-section hover color on `/work` project titles: each title now hovers in its section accent color via `--cin-hover` CSS var
- Fix cinematic reveal on SPA navigation: synchronous `getBoundingClientRect` check for in-viewport sections prevents the async IO callback delay during Astro View Transitions

## Test plan

- [ ] Light mode: `/`, `/blog`, `/work`, `/cv` — colors correct
- [ ] Dark mode: same pages — accent violet, text/bg tokens apply
- [ ] SPA navigation to `/blog` and `/work` — cinematic sections revealed immediately, no flash of invisible content
- [ ] `/work` title hover: IMS=violet, aitorevi.dev=blue, Colorprof=emerald, IRPH=sky
- [ ] `npx astro check` → 0 errors
- [ ] `npm run test:unit` → all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)