### PR TITLE
feat(work): redesign aitorevi-dev case study hero and CTAs

### DIFF
--- a/src/components/case-study/SelfContent.astro
+++ b/src/components/case-study/SelfContent.astro
@@ -19,7 +19,6 @@ const { lang } = Astro.props;
 const isES = lang === 'es';
 
 
-const blogPath = isES ? '/blog' : '/en/blog';
 const contactPath = isES ? '/#contact' : '/en/#contact';
 const repoUrl = 'https://github.com/aitorevi/aitorevi-blog';
 
@@ -109,23 +108,23 @@ const stack: Record<'frontend' | 'content' | 'infra' | 'testing', TechItem[]> = 
         <p class="mx-auto mt-4 max-w-2xl text-lg leading-relaxed text-slate-600 dark:text-slate-400">
           {t(lang, 'portfolio.self.hero.subtitle')}
         </p>
-        <div class="mt-8 flex flex-wrap items-center justify-center gap-3">
-          <Button href={repoUrl} target="_blank" tone="violet">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-4 w-4" aria-hidden="true">
-              <path d="M12 .5C5.37.5 0 5.87 0 12.5a12 12 0 0 0 8.21 11.41c.6.11.82-.26.82-.58v-2.23c-3.34.73-4.04-1.61-4.04-1.61-.55-1.4-1.33-1.78-1.33-1.78-1.08-.74.08-.73.08-.73 1.2.08 1.83 1.24 1.83 1.24 1.07 1.83 2.8 1.3 3.49.99.11-.78.42-1.3.76-1.6-2.67-.3-5.47-1.34-5.47-5.95 0-1.32.47-2.39 1.24-3.24-.13-.3-.54-1.52.11-3.18 0 0 1.01-.32 3.3 1.24a11.4 11.4 0 0 1 6 0c2.29-1.56 3.3-1.24 3.3-1.24.66 1.66.24 2.88.12 3.18.77.85 1.23 1.92 1.23 3.24 0 4.62-2.81 5.65-5.49 5.94.43.38.82 1.12.82 2.26v3.35c0 .32.22.7.83.58A12 12 0 0 0 24 12.5C24 5.87 18.63.5 12 .5Z" />
-            </svg>
-            <span>{t(lang, 'portfolio.self.hero.ctaRepo')}</span>
-          </Button>
-          <Button href={contactPath} tone="blue">
-            <span>{t(lang, 'portfolio.self.cta.contact')}</span>
-          </Button>
-          <Button href="/styleguide" tone="violet" variant="gradient">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4" aria-hidden="true">
-              <circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/><circle cx="6.5" cy="12.5" r=".5" fill="currentColor"/>
-              <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"/>
-            </svg>
-            <span>{isES ? 'Design system' : 'Design system'}</span>
-          </Button>
+        <div class="mt-8 flex justify-center">
+          <div
+            class="inline-flex items-center gap-3 rounded-full border border-secondary/15 bg-white/70 px-4 py-2.5 backdrop-blur-sm shadow-glow-accent-card-md dark:border-accent-violet/20 dark:bg-ink-800/70"
+            role="img"
+            aria-label="aitorevi.dev"
+          >
+            <span class="flex shrink-0 items-center gap-1.5" aria-hidden="true">
+              <span class="h-2 w-2 rounded-full bg-rose-400/70 dark:bg-rose-400/60" />
+              <span class="h-2 w-2 rounded-full bg-amber-400/70 dark:bg-amber-400/60" />
+              <span class="h-2 w-2 rounded-full bg-emerald-400/70 dark:bg-emerald-400/60" />
+            </span>
+            <span class="h-4 w-px bg-secondary/15 dark:bg-accent-violet/20" aria-hidden="true" />
+            <span class="font-mono text-base sm:text-xl font-semibold tracking-tight">
+              <span class="text-fg-subtle dark:text-slate-500" aria-hidden="true">https://</span>
+              <span class="bg-home-gradient-text-light bg-clip-text text-transparent dark:bg-home-gradient-text">aitorevi.dev</span>
+            </span>
+          </div>
         </div>
       </div>
     </section>
@@ -305,6 +304,31 @@ const stack: Record<'frontend' | 'content' | 'infra' | 'testing', TechItem[]> = 
       </div>
     </section>
 
+    <!-- Design system -->
+    <section class="bg-slate-50 py-20 dark:bg-ink-900 sm:py-24" aria-labelledby="self-design-system">
+      <div class="mx-auto max-w-2xl px-6 text-center">
+        <SectionHeader
+          id="self-design-system"
+          title={isES ? 'Todos los estilos, documentados' : 'Every style, documented'}
+          subtitle={isES ? 'Design system' : 'Design system'}
+        />
+        <p class="mx-auto mt-6 text-base leading-relaxed text-slate-600 dark:text-slate-400">
+          {isES
+            ? 'Tokens de color, tipografía, sombras, animaciones y componentes. Con dark mode en vivo y modo retro.'
+            : 'Color tokens, typography, shadows, animations and components. With live dark mode and retro mode.'}
+        </p>
+        <div class="mt-8">
+          <Button href="/styleguide" tone="violet" variant="gradient">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4" aria-hidden="true">
+              <circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/><circle cx="6.5" cy="12.5" r=".5" fill="currentColor"/>
+              <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"/>
+            </svg>
+            <span>{isES ? 'Ver design system' : 'View design system'}</span>
+          </Button>
+        </div>
+      </div>
+    </section>
+
     <!-- Final CTA -->
     <section class="bg-white py-20 dark:bg-ink-900/50 sm:py-24" aria-labelledby="self-cta">
       <div class="mx-auto max-w-2xl px-6 text-center">
@@ -323,13 +347,6 @@ const stack: Record<'frontend' | 'content' | 'infra' | 'testing', TechItem[]> = 
           </Button>
           <Button href={contactPath} tone="blue">
             <span>{t(lang, 'portfolio.self.cta.contact')}</span>
-          </Button>
-          <Button href="/styleguide" tone="violet" variant="gradient">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4" aria-hidden="true">
-              <circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/><circle cx="6.5" cy="12.5" r=".5" fill="currentColor"/>
-              <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"/>
-            </svg>
-            <span>{isES ? 'Design system' : 'Design system'}</span>
           </Button>
         </div>
       </div>

--- a/src/i18n/messages/cv.ts
+++ b/src/i18n/messages/cv.ts
@@ -81,7 +81,7 @@ export const cv = {
     'portfolio.self.scores.source': 'Medido con PageSpeed Insights en aitorevi.dev',
 
     'portfolio.self.cta.title': 'El código es abierto',
-    'portfolio.self.cta.text': 'Si has llegado hasta aquí, quizá te apetezca leer un post o escribirme.',
+    'portfolio.self.cta.text': 'Si has llegado hasta aquí, no dudes en escribirme.',
     'portfolio.self.cta.github': 'Ver repo en GitHub',
     'portfolio.self.cta.blog': 'Ir al blog',
     'portfolio.self.cta.contact': 'Escribirme',
@@ -168,7 +168,7 @@ export const cv = {
     'portfolio.self.scores.source': 'Measured with PageSpeed Insights on aitorevi.dev',
 
     'portfolio.self.cta.title': 'The code is open',
-    'portfolio.self.cta.text': 'If you made it this far, maybe you want to read a post or reach out.',
+    'portfolio.self.cta.text': 'If you made it this far, feel free to reach out.',
     'portfolio.self.cta.github': 'View repo on GitHub',
     'portfolio.self.cta.blog': 'Go to the blog',
     'portfolio.self.cta.contact': 'Write me',


### PR DESCRIPTION
## Summary

- Hero now ends with a browser URL pill (`https://aitorevi.dev`) instead of buttons — makes the page identity immediately clear
- Blog buttons removed throughout; hero has no CTA buttons
- Design system promoted to its own full section (with `SectionHeader`, description and button) placed above the final CTA
- Final CTA simplified to GitHub + contact only, copy updated to remove the "leer un post" reference
- Removed unused `blogPath` variable

## Test plan

- [ ] `/work/aitorevi-dev` — hero shows URL pill, no buttons
- [ ] Design system section appears above "El código es abierto"
- [ ] "Ver design system" button links to `/styleguide`
- [ ] Final CTA shows only GitHub and Escríbeme buttons
- [ ] EN version `/en/work/aitorevi-dev` renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)