### PR TITLE
feat(work): add design system browser mock to case study

### DIFF
--- a/src/components/case-study/SelfContent.astro
+++ b/src/components/case-study/SelfContent.astro
@@ -335,6 +335,11 @@ const stack: Record<'frontend' | 'content' | 'infra' | 'testing', TechItem[]> = 
 
         <!-- Right column: browser-chrome mock previewing the styleguide.
              Same construction as WorkCinematic mocks (chrome + aspect-[4/3] body). -->
+        <a
+          href="/styleguide"
+          class="ds-mock block"
+          aria-label={isES ? 'Ver design system' : 'View design system'}
+        >
         <div
           class="relative overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-br from-ink-800 to-ink-900 p-1 shadow-2xl ring-1 ring-accent-violet/40"
           aria-hidden="true"
@@ -394,6 +399,7 @@ const stack: Record<'frontend' | 'content' | 'infra' | 'testing', TechItem[]> = 
             </div>
           </div>
         </div>
+        </a>
       </div>
     </section>
 
@@ -422,6 +428,24 @@ const stack: Record<'frontend' | 'content' | 'infra' | 'testing', TechItem[]> = 
 
   </div>
 </Layout>
+
+<style>
+  .ds-mock {
+    display: block;
+    transform: perspective(1400px) rotateX(2deg) rotateY(-3deg);
+    transition: transform 600ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  .ds-mock:hover {
+    transform: perspective(1400px) rotateX(0deg) rotateY(0deg);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .ds-mock,
+    .ds-mock:hover {
+      transform: none;
+      transition: none;
+    }
+  }
+</style>
 
 <script>
   // Lighthouse-score badges: same IntersectionObserver + ease-out pattern

--- a/src/components/case-study/SelfContent.astro
+++ b/src/components/case-study/SelfContent.astro
@@ -306,25 +306,93 @@ const stack: Record<'frontend' | 'content' | 'infra' | 'testing', TechItem[]> = 
 
     <!-- Design system -->
     <section class="bg-slate-50 py-20 dark:bg-ink-900 sm:py-24" aria-labelledby="self-design-system">
-      <div class="mx-auto max-w-2xl px-6 text-center">
-        <SectionHeader
-          id="self-design-system"
-          title={isES ? 'Todos los estilos, documentados' : 'Every style, documented'}
-          subtitle={isES ? 'Design system' : 'Design system'}
-        />
-        <p class="mx-auto mt-6 text-base leading-relaxed text-slate-600 dark:text-slate-400">
-          {isES
-            ? 'Tokens de color, tipografía, sombras, animaciones y componentes. Con dark mode en vivo y modo retro.'
-            : 'Color tokens, typography, shadows, animations and components. With live dark mode and retro mode.'}
-        </p>
-        <div class="mt-8">
-          <Button href="/styleguide" tone="violet" variant="gradient">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4" aria-hidden="true">
-              <circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/><circle cx="6.5" cy="12.5" r=".5" fill="currentColor"/>
-              <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"/>
-            </svg>
-            <span>{isES ? 'Ver design system' : 'View design system'}</span>
-          </Button>
+      <div class="mx-auto grid max-w-5xl grid-cols-1 items-center gap-10 px-6 md:grid-cols-2 md:gap-14">
+        <!-- Left column: heading, description, CTA. SectionHeader is centered
+             by design (shared atom) — we keep that on mobile and md+ to stay
+             consistent with every other section in this case study. The mock
+             on the right balances the column visually. -->
+        <div>
+          <SectionHeader
+            id="self-design-system"
+            title={isES ? 'Todos los estilos, documentados' : 'Every style, documented'}
+            subtitle={isES ? 'Design system' : 'Design system'}
+          />
+          <p class="mt-6 text-center text-base leading-relaxed text-slate-600 dark:text-slate-400">
+            {isES
+              ? 'Tokens de color, tipografía, sombras, animaciones y componentes. Con dark mode en vivo y modo retro.'
+              : 'Color tokens, typography, shadows, animations and components. With live dark mode and retro mode.'}
+          </p>
+          <div class="mt-8 flex justify-center">
+            <Button href="/styleguide" tone="violet" variant="gradient">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4" aria-hidden="true">
+                <circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/><circle cx="6.5" cy="12.5" r=".5" fill="currentColor"/>
+                <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"/>
+              </svg>
+              <span>{isES ? 'Ver design system' : 'View design system'}</span>
+            </Button>
+          </div>
+        </div>
+
+        <!-- Right column: browser-chrome mock previewing the styleguide.
+             Same construction as WorkCinematic mocks (chrome + aspect-[4/3] body). -->
+        <div
+          class="relative overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-br from-ink-800 to-ink-900 p-1 shadow-2xl ring-1 ring-accent-violet/40"
+          aria-hidden="true"
+        >
+          <!-- Browser chrome -->
+          <div class="flex items-center gap-1.5 border-b border-white/5 bg-ink-800/95 px-4 py-2.5 backdrop-blur">
+            <span class="h-2.5 w-2.5 rounded-full bg-red-400/70"></span>
+            <span class="h-2.5 w-2.5 rounded-full bg-yellow-400/70"></span>
+            <span class="h-2.5 w-2.5 rounded-full bg-green-400/70"></span>
+            <span class="ml-4 truncate font-mono text-[10px] text-slate-400">aitorevi.dev/styleguide</span>
+          </div>
+
+          <!-- Body — styleguide preview -->
+          <div class="relative aspect-[4/3] bg-ink-900 p-4 md:p-5">
+            <div class="flex h-full flex-col gap-3">
+              <!-- Section label -->
+              <div class="font-mono text-[9px] uppercase tracking-[0.25em] text-slate-500">
+                {isES ? 'Tokens · paleta' : 'Tokens · palette'}
+              </div>
+
+              <!-- Color palette: the four real accent tokens -->
+              <div class="grid grid-cols-4 gap-2">
+                <div class="aspect-square rounded-md bg-accent-violet/90 ring-1 ring-inset ring-white/10"></div>
+                <div class="aspect-square rounded-md bg-accent-blue/90 ring-1 ring-inset ring-white/10"></div>
+                <div class="aspect-square rounded-md bg-accent-sky/90 ring-1 ring-inset ring-white/10"></div>
+                <div class="aspect-square rounded-md bg-emerald-400/90 ring-1 ring-inset ring-white/10"></div>
+              </div>
+
+              <!-- Typography specimen + glow swatch -->
+              <div class="grid grid-cols-3 gap-2">
+                <div class="col-span-2 flex items-center gap-3 rounded-md border border-white/5 bg-white/[0.02] px-3 py-2">
+                  <span class="font-display text-2xl font-black leading-none text-slate-100">Aa</span>
+                  <div class="flex flex-col leading-tight">
+                    <span class="font-mono text-[9px] uppercase tracking-[0.18em] text-accent-violet/80">Outfit</span>
+                    <span class="font-mono text-[9px] text-slate-500">display · 700</span>
+                  </div>
+                </div>
+                <!-- Glow swatch echoing shadow-glow-accent-card-md -->
+                <div class="relative overflow-hidden rounded-md border border-white/5 bg-ink-800">
+                  <div class="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(167,139,250,0.55),transparent_70%)]"></div>
+                  <span class="absolute bottom-1.5 left-2 font-mono text-[9px] uppercase tracking-[0.18em] text-slate-400">glow</span>
+                </div>
+              </div>
+
+              <!-- Button row -->
+              <div class="mt-auto flex flex-wrap items-center gap-2">
+                <span class="rounded-full bg-gradient-to-r from-accent-violet to-accent-blue px-3 py-1 font-mono text-[9px] uppercase tracking-[0.18em] text-white">
+                  Primary
+                </span>
+                <span class="rounded-full border border-accent-blue/40 bg-accent-blue/10 px-3 py-1 font-mono text-[9px] uppercase tracking-[0.18em] text-accent-blue">
+                  Secondary
+                </span>
+                <span class="rounded-full border border-white/10 bg-white/[0.03] px-3 py-1 font-mono text-[9px] uppercase tracking-[0.18em] text-slate-400">
+                  Ghost
+                </span>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </section>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -131,7 +131,7 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `https://www.aitorevi.
 	</head>
 	<body
 		class="flex flex-col min-h-dvh bg-white dark:bg-page text-primary dark:text-fg scrollbar scrollbar-thumb-primary scrollbar-w-2 scrollbar-corner-rounded-xl"
-		data-bg={variant === 'default' ? undefined : variant}
+		data-bg={variant}
 	>
 		<a
 			href="#main-content"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -23,8 +23,8 @@ interface Props {
 	 * lives elsewhere. This value is used for both `<link rel="canonical">` and `<meta property="og:url">`.
 	 */
 	canonicalUrl?: string;
-	/** Background variant. `dark-radial` applies the slate palette + radial gradient used on content pages (cv, blog, katas). */
-	variant?: 'default' | 'dark-radial';
+	/** Background variant. `dark-radial` applies the slate palette + radial gradient used on content pages (cv, blog, katas). `flat` applies slate-50/ink-900 with no gradient (case study pages). */
+	variant?: 'default' | 'dark-radial' | 'flat';
 }
 
 const currentLang = getLangFromUrl(Astro.url);
@@ -158,6 +158,15 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `https://www.aitorevi.
 		background-color: theme(colors.ink.900);
 		background-image: radial-gradient(ellipse at 30% 20%, theme(colors.ink.700) 0%, theme(colors.ink.900) 55%, #000 100%);
 		background-size: cover;
+	}
+
+	body[data-bg="flat"] {
+		background-color: #f8fafc;
+		background-image: linear-gradient(180deg, rgb(94 58 238 / 0.05) 0%, transparent 30%);
+	}
+	html.dark body[data-bg="flat"] {
+		background-color: #020617;
+		background-image: linear-gradient(180deg, rgb(96 165 250 / 0.05) 0%, transparent 30%);
 	}
 
 	::-webkit-scrollbar {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -161,12 +161,10 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `https://www.aitorevi.
 	}
 
 	body[data-bg="flat"] {
-		background-color: #f8fafc;
-		background-image: linear-gradient(180deg, rgb(94 58 238 / 0.05) 0%, transparent 30%);
+		background-color: #f2f2fc;
 	}
 	html.dark body[data-bg="flat"] {
-		background-color: #020617;
-		background-image: linear-gradient(180deg, rgb(96 165 250 / 0.05) 0%, transparent 30%);
+		background-color: #050b1f;
 	}
 
 	::-webkit-scrollbar {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -161,10 +161,7 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `https://www.aitorevi.
 	}
 
 	body[data-bg="flat"] {
-		background-color: #f2f2fc;
-	}
-	html.dark body[data-bg="flat"] {
-		background-color: #050b1f;
+		background-color: rgb(var(--color-bg-content));
 	}
 
 	::-webkit-scrollbar {

--- a/src/pages/styleguide.astro
+++ b/src/pages/styleguide.astro
@@ -82,17 +82,22 @@ const simpleIcons = [
 
     <!-- ── HEADER ────────────────────────────────────────────────── -->
     <section class="space-y-3">
-      <div class="flex items-center gap-4">
+      <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <EyebrowTag label="Design System" />
-        <a
-          href="/work/aitorevi-dev"
-          class="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest text-fg-muted transition-colors hover:text-accent"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-3 w-3" aria-hidden="true">
-            <path fill-rule="evenodd" d="M9.78 4.22a.75.75 0 0 1 0 1.06L7.06 8l2.72 2.72a.75.75 0 1 1-1.06 1.06L5.47 8.53a.75.75 0 0 1 0-1.06l3.25-3.25a.75.75 0 0 1 1.06 0Z" clip-rule="evenodd" />
+        <Button href="/work/aitorevi-dev" tone="violet" variant="ghost">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="2"
+            stroke="currentColor"
+            class="h-4 w-4 transition-transform group-hover:-translate-x-0.5"
+            aria-hidden="true"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
           </svg>
-          aitorevi.dev case study
-        </a>
+          <span>Volver al caso de estudio</span>
+        </Button>
       </div>
       <h1 class="font-display text-4xl font-black text-fg sm:text-5xl">Style Guide</h1>
       <p class="font-mono text-sm text-fg-muted max-w-xl">
@@ -632,6 +637,29 @@ console.log(greeting('aitorevi'));</code></pre>
         </div>
       </div>
     </section>
+
+    <!-- ── BACK LINK (bottom) ─────────────────────────────────────── -->
+    <footer class="border-t border-black/10 pt-12 dark:border-white/10">
+      <div class="flex flex-col items-center gap-6">
+        <p class="font-mono text-[10px] uppercase tracking-[0.3em] text-fg-muted">
+          // volver al caso de estudio
+        </p>
+        <Button href="/work/aitorevi-dev" tone="violet" variant="ghost">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="2"
+            stroke="currentColor"
+            class="h-4 w-4 transition-transform group-hover:-translate-x-0.5"
+            aria-hidden="true"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
+          </svg>
+          <span>Volver al caso de estudio</span>
+        </Button>
+      </div>
+    </footer>
 
   </main>
 </Layout>

--- a/src/pages/styleguide.astro
+++ b/src/pages/styleguide.astro
@@ -78,7 +78,7 @@ const simpleIcons = [
 ---
 
 <Layout title="Style Guide — aitorevi.dev" lang="es" description="Design tokens, componentes y estilos del blog">
-  <div class="min-h-dvh bg-slate-50 text-ink-900 dark:bg-ink-900 dark:text-slate-100">
+  <div class="styleguide-root min-h-dvh bg-slate-50 text-ink-900 dark:bg-ink-900 dark:text-slate-100">
   <main class="mx-auto max-w-5xl px-6 pt-28 pb-16 space-y-20">
 
     <!-- ── HEADER ────────────────────────────────────────────────── -->
@@ -652,6 +652,15 @@ console.log(greeting('aitorevi'));</code></pre>
   </main>
   </div>
 </Layout>
+
+<style is:global>
+  body:has(.styleguide-root) {
+    background-color: #f8fafc; /* slate-50 */
+  }
+  html.dark body:has(.styleguide-root) {
+    background-color: #020617; /* ink-900 */
+  }
+</style>
 
 <script>
   // ScoreBadge animation — reuses the same pattern from SelfContent.astro

--- a/src/pages/styleguide.astro
+++ b/src/pages/styleguide.astro
@@ -635,22 +635,17 @@ console.log(greeting('aitorevi'));</code></pre>
     </section>
 
     <!-- ── BACK LINK (bottom) ─────────────────────────────────────── -->
-    <footer class="border-t border-black/10 pt-12 dark:border-white/10">
-      <div class="flex flex-col items-center gap-6">
-        <p class="font-mono text-[10px] uppercase tracking-[0.3em] text-fg-muted">
-          // volver al caso de estudio
-        </p>
-        <a
-          href="/work/aitorevi-dev"
-          class="group inline-flex items-center gap-3 font-mono text-xs uppercase tracking-[0.25em] text-accent focus:outline-none focus-visible:underline"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4 transition-transform duration-500 group-hover:-translate-x-1" aria-hidden="true">
-            <path d="M19 12H5M11 5l-7 7 7 7" />
-          </svg>
-          <span class="relative h-px w-10 bg-accent transition-all duration-500 group-hover:w-16"></span>
-          <span>Caso de estudio</span>
-        </a>
-      </div>
+    <footer class="flex justify-end">
+      <a
+        href="/work/aitorevi-dev"
+        class="group inline-flex items-center gap-3 font-mono text-xs uppercase tracking-[0.25em] text-accent focus:outline-none focus-visible:underline"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4 transition-transform duration-500 group-hover:-translate-x-1" aria-hidden="true">
+          <path d="M19 12H5M11 5l-7 7 7 7" />
+        </svg>
+        <span class="relative h-px w-10 bg-accent transition-all duration-500 group-hover:w-16"></span>
+        <span>Caso de estudio</span>
+      </a>
     </footer>
 
   </main>

--- a/src/pages/styleguide.astro
+++ b/src/pages/styleguide.astro
@@ -77,9 +77,8 @@ const simpleIcons = [
 ];
 ---
 
-<Layout title="Style Guide — aitorevi.dev" lang="es" description="Design tokens, componentes y estilos del blog">
-  <div class="styleguide-root min-h-dvh bg-slate-50 text-ink-900 dark:bg-ink-900 dark:text-slate-100">
-  <main class="mx-auto max-w-5xl px-6 pt-28 pb-16 space-y-20">
+<Layout title="Style Guide — aitorevi.dev" lang="es" description="Design tokens, componentes y estilos del blog" variant="flat">
+  <main class="mx-auto max-w-5xl px-6 pt-28 pb-16 space-y-20 text-ink-900 dark:text-slate-100">
 
     <!-- ── HEADER ────────────────────────────────────────────────── -->
     <section class="space-y-3">
@@ -650,17 +649,8 @@ console.log(greeting('aitorevi'));</code></pre>
     </footer>
 
   </main>
-  </div>
 </Layout>
 
-<style is:global>
-  body:has(.styleguide-root) {
-    background-color: #f8fafc; /* slate-50 */
-  }
-  html.dark body:has(.styleguide-root) {
-    background-color: #020617; /* ink-900 */
-  }
-</style>
 
 <script>
   // ScoreBadge animation — reuses the same pattern from SelfContent.astro

--- a/src/pages/styleguide.astro
+++ b/src/pages/styleguide.astro
@@ -78,7 +78,7 @@ const simpleIcons = [
 ---
 
 <Layout title="Style Guide — aitorevi.dev" lang="es" description="Design tokens, componentes y estilos del blog">
-  <div class="bg-slate-50 text-ink-900 dark:bg-ink-900 dark:text-slate-100">
+  <div class="min-h-dvh bg-slate-50 text-ink-900 dark:bg-ink-900 dark:text-slate-100">
   <main class="mx-auto max-w-5xl px-6 pt-28 pb-16 space-y-20">
 
     <!-- ── HEADER ────────────────────────────────────────────────── -->

--- a/src/pages/styleguide.astro
+++ b/src/pages/styleguide.astro
@@ -84,20 +84,16 @@ const simpleIcons = [
     <section class="space-y-3">
       <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <EyebrowTag label="Design System" />
-        <Button href="/work/aitorevi-dev" tone="violet" variant="ghost">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke-width="2"
-            stroke="currentColor"
-            class="h-4 w-4 transition-transform group-hover:-translate-x-0.5"
-            aria-hidden="true"
-          >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
+        <a
+          href="/work/aitorevi-dev"
+          class="group inline-flex items-center gap-3 font-mono text-xs uppercase tracking-[0.25em] text-accent focus:outline-none focus-visible:underline"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4 transition-transform duration-500 group-hover:-translate-x-1" aria-hidden="true">
+            <path d="M19 12H5M11 5l-7 7 7 7" />
           </svg>
-          <span>Volver al caso de estudio</span>
-        </Button>
+          <span class="relative h-px w-10 bg-accent transition-all duration-500 group-hover:w-16"></span>
+          <span>Caso de estudio</span>
+        </a>
       </div>
       <h1 class="font-display text-4xl font-black text-fg sm:text-5xl">Style Guide</h1>
       <p class="font-mono text-sm text-fg-muted max-w-xl">
@@ -644,20 +640,16 @@ console.log(greeting('aitorevi'));</code></pre>
         <p class="font-mono text-[10px] uppercase tracking-[0.3em] text-fg-muted">
           // volver al caso de estudio
         </p>
-        <Button href="/work/aitorevi-dev" tone="violet" variant="ghost">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke-width="2"
-            stroke="currentColor"
-            class="h-4 w-4 transition-transform group-hover:-translate-x-0.5"
-            aria-hidden="true"
-          >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
+        <a
+          href="/work/aitorevi-dev"
+          class="group inline-flex items-center gap-3 font-mono text-xs uppercase tracking-[0.25em] text-accent focus:outline-none focus-visible:underline"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4 transition-transform duration-500 group-hover:-translate-x-1" aria-hidden="true">
+            <path d="M19 12H5M11 5l-7 7 7 7" />
           </svg>
-          <span>Volver al caso de estudio</span>
-        </Button>
+          <span class="relative h-px w-10 bg-accent transition-all duration-500 group-hover:w-16"></span>
+          <span>Caso de estudio</span>
+        </a>
       </div>
     </footer>
 

--- a/src/pages/styleguide.astro
+++ b/src/pages/styleguide.astro
@@ -78,6 +78,7 @@ const simpleIcons = [
 ---
 
 <Layout title="Style Guide — aitorevi.dev" lang="es" description="Design tokens, componentes y estilos del blog">
+  <div class="bg-slate-50 text-ink-900 dark:bg-ink-900 dark:text-slate-100">
   <main class="mx-auto max-w-5xl px-6 pt-28 pb-16 space-y-20">
 
     <!-- ── HEADER ────────────────────────────────────────────────── -->
@@ -649,6 +650,7 @@ console.log(greeting('aitorevi'));</code></pre>
     </footer>
 
   </main>
+  </div>
 </Layout>
 
 <script>

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -13,6 +13,7 @@
 :root {
   /* ── Page background ──────────────────────────────────────────────── */
   --color-bg: 255 255 255;        /* white */
+  --color-bg-content: 242 242 252;  /* #f2f2fc — case study / design system pages */
   --color-surface: 255 255 255;   /* card surface */
 
   /* ── Text ─────────────────────────────────────────────────────────── */
@@ -49,6 +50,7 @@
 .dark {
   /* ── Page background ──────────────────────────────────────────────── */
   --color-bg: 15 20 25;           /* #0f1419 — body dark (unificado) */
+  --color-bg-content: 5 11 31;      /* #050b1f — case study / design system pages */
   --color-surface: 11 17 32;      /* ink-800 #0b1120 */
 
   /* ── Text ─────────────────────────────────────────────────────────── */

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -17,6 +17,8 @@ export default {
 				},
 				// Page background token (bg-page switches light/dark automatically)
 				page: 'rgb(var(--color-bg) / <alpha-value>)',
+				// Content page background — case study / design system pages
+				'content-page': 'rgb(var(--color-bg-content) / <alpha-value>)',
 				// Foreground text token (text-fg switches light/dark automatically)
 				fg:   'rgb(var(--color-fg) / <alpha-value>)',
 


### PR DESCRIPTION
## Summary

- Design System section in the aitorevi-dev case study now has a two-column layout on md+ screens
- Right column: browser chrome mock (`aitorevi.dev/styleguide`) with inline content showing color swatches (violet/blue/sky/emerald), typography specimen (Outfit Aa), a glow swatch, and button pills
- Same construction as WorkCinematic mocks — `aspect-[4/3]`, `bg-ink-900` body, chrome dots + mono URL
- Left column: existing SectionHeader, description and "Ver design system" button
- `aria-hidden="true"` on the mock — purely decorative

## Test plan

- [ ] `/work/aitorevi-dev` — design system section shows two columns on desktop, stacks on mobile
- [ ] Mock renders correctly in both light and dark mode
- [ ] `astro check` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)