### PR TITLE
fix: formato dd/mm/yyyy en páginas legales y limpieza de locales

### DIFF
--- a/src/components/home/Talks.astro
+++ b/src/components/home/Talks.astro
@@ -1,6 +1,6 @@
 ---
 import type { Lang } from '@/i18n/types';
-import { t } from '@/i18n/utils';
+import { t, getLangLocale } from '@/i18n/utils';
 import { talks } from '@/data/talks';
 import { formatDate, formatDateISO } from '@/lib/date';
 import SectionHeader from '@/components/shared/SectionHeader.astro';
@@ -13,7 +13,7 @@ interface Props {
 
 const { lang } = Astro.props;
 
-const locale = lang === 'en' ? 'en-US' : 'es-ES';
+const locale = getLangLocale(lang);
 const sorted = [...talks].sort((a, b) => (a.date < b.date ? 1 : -1));
 const isSingle = sorted.length === 1;
 const listClass = isSingle

--- a/src/components/legal/LegalPageLayout.astro
+++ b/src/components/legal/LegalPageLayout.astro
@@ -2,6 +2,7 @@
 import Layout from '@/layouts/Layout.astro';
 import { t } from '@/i18n/utils';
 import type { Lang } from '@/i18n/types';
+import { formatDateShort } from '@/lib/date';
 
 interface Props {
   title: string;
@@ -23,7 +24,7 @@ const { title, description, lang, updatedDate } = Astro.props;
         {title}
       </h1>
       <p class="mt-3 text-sm text-slate-500 dark:text-slate-400">
-        {t(lang, 'legal.updated')}: <time datetime={updatedDate}>{updatedDate}</time>
+        {t(lang, 'legal.updated')}: <time datetime={updatedDate}>{formatDateShort(updatedDate)}</time>
       </p>
     </header>
 

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -34,6 +34,20 @@ export function formatDateISO(date: Date | string): string {
 }
 
 /**
+ * Formats a date to dd/mm/yyyy for legal pages and similar contexts
+ * where a locale-neutral numeric format is expected.
+ * @param date - Date object or ISO string
+ * @returns Formatted date string (e.g., "22/04/2026")
+ */
+export function formatDateShort(date: Date | string): string {
+  const dateObj = typeof date === 'string' ? new Date(date) : date;
+  const day = String(dateObj.getUTCDate()).padStart(2, '0');
+  const month = String(dateObj.getUTCMonth() + 1).padStart(2, '0');
+  const year = dateObj.getUTCFullYear();
+  return `${day}/${month}/${year}`;
+}
+
+/**
  * Calculates relative time from now (e.g., "2 days ago")
  * @param date - Date object or ISO string
  * @param locale - BCP 47 language tag (default: 'en-US')

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -10,7 +10,7 @@ import PostNavigation from '@/components/blog/PostNavigation.astro';
 import { calculateReadingTime } from '@/lib/blog';
 import { formatDate, formatDateISO } from '@/lib/date';
 import DotField from '@/components/shared/DotField.astro';
-import { t, getBlogSlugFromId } from '@/i18n/utils';
+import { t, getBlogSlugFromId, getLangLocale } from '@/i18n/utils';
 import { safeJsonLd } from '@/lib/schema-org';
 
 interface NavPost {
@@ -176,7 +176,7 @@ const coverImageAbsolute = toAbsoluteUrl(coverImageUrl);
                   datetime={formatDateISO(data.updatedDate)}
                   class="normal-case tracking-normal text-xs text-slate-500"
                 >
-                  {t(lang, 'blog.updated')} {formatDate(data.updatedDate, 'es-ES')}
+                  {t(lang, 'blog.updated')} {formatDate(data.updatedDate, getLangLocale(lang))}
                 </time>
               </>
             )}

--- a/src/pages/en/blog/[...slug].astro
+++ b/src/pages/en/blog/[...slug].astro
@@ -10,7 +10,7 @@ import PostNavigation from '@/components/blog/PostNavigation.astro';
 import { calculateReadingTime } from '@/lib/blog';
 import { formatDate, formatDateISO } from '@/lib/date';
 import DotField from '@/components/shared/DotField.astro';
-import { t, getBlogSlugFromId } from '@/i18n/utils';
+import { t, getBlogSlugFromId, getLangLocale } from '@/i18n/utils';
 import { safeJsonLd } from '@/lib/schema-org';
 
 interface NavPost {
@@ -170,7 +170,7 @@ const coverImageAbsolute = toAbsoluteUrl(coverImageUrl);
                   datetime={formatDateISO(data.updatedDate)}
                   class="normal-case tracking-normal text-xs text-slate-500"
                 >
-                  {t(lang, 'blog.updated')} {formatDate(data.updatedDate, 'en-US')}
+                  {t(lang, 'blog.updated')} {formatDate(data.updatedDate, getLangLocale(lang))}
                 </time>
               </>
             )}

--- a/tests/unit/lib/date.test.ts
+++ b/tests/unit/lib/date.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatDate, formatDateISO, getRelativeTime } from '@/lib/date';
+import { formatDate, formatDateISO, formatDateShort, getRelativeTime } from '@/lib/date';
 
 describe('formatDate', () => {
   it('formats a Date object in en-US', () => {
@@ -17,6 +17,20 @@ describe('formatDate', () => {
   it('uses en-US as default locale', () => {
     const result = formatDate('2026-06-15');
     expect(result).toContain('June');
+  });
+});
+
+describe('formatDateShort', () => {
+  it('formats an ISO string to dd/mm/yyyy', () => {
+    expect(formatDateShort('2026-04-22')).toBe('22/04/2026');
+  });
+
+  it('formats a Date object to dd/mm/yyyy', () => {
+    expect(formatDateShort(new Date('2026-04-22T00:00:00Z'))).toBe('22/04/2026');
+  });
+
+  it('pads single-digit day and month', () => {
+    expect(formatDateShort('2026-01-05')).toBe('05/01/2026');
   });
 });
 

--- a/workspace/review/legal-date-format.md
+++ b/workspace/review/legal-date-format.md
@@ -1,0 +1,42 @@
+# legal-date-format
+
+**Issue:** #212 — Formato fecha  
+**Status:** REVIEW  
+**Type:** Fix operacional  
+**Branch:** fix/legal-date-format  
+**Worktree:** ../aitorevi-blog-fix-legal-date-format
+
+## Contexto
+
+Las 6 páginas legales (3 ES + 3 EN) muestran la fecha de última actualización como string ISO crudo (`2026-04-22`) en lugar del formato `dd/mm/yyyy` esperado. El componente `LegalPageLayout.astro` recibe `updatedDate` como string y lo renderiza sin formatear.
+
+Ya existe `src/lib/date.ts` con funciones de formateo, pero ninguna produce `dd/mm/yyyy`. Ya existe `DateDisplay.astro` para fechas de blog, pero usa formato de lenguaje natural (ej. "22 de abril de 2026").
+
+Adicionalmente hay inconsistencias menores en el resto del site donde el locale se resuelve con ternarios hardcodeados en lugar de usar el helper centralizado `getLangLocale()`.
+
+## Decisión de diseño
+
+- Añadir función `formatDateShort(date)` en `src/lib/date.ts` que devuelva `dd/mm/yyyy`
+- Usar esa función en `LegalPageLayout.astro`
+- No tocar `DateDisplay.astro` (usa formato diferente para blog posts — correcto)
+- Limpiar los locales hardcodeados en blog post pages y `Talks.astro` para que usen `getLangLocale()`
+
+## Checklist
+
+- [x] Añadir `formatDateShort` en `src/lib/date.ts` (retorna `dd/mm/yyyy`)
+- [x] Añadir test unitario para `formatDateShort` en `tests/unit/date.test.ts`
+- [x] Actualizar `LegalPageLayout.astro` para usar `formatDateShort(updatedDate)` en el texto visible
+- [x] Limpiar `src/pages/blog/[...slug].astro` — reemplazar `'es-ES'` hardcodeado por `getLangLocale(lang)`
+- [x] Limpiar `src/pages/en/blog/[...slug].astro` — reemplazar `'en-US'` hardcodeado por `getLangLocale(lang)`
+- [x] Limpiar `src/components/home/Talks.astro` — reemplazar ternario por `getLangLocale(lang)`
+- [x] `npx astro check` — 0 errores
+- [x] `npm run test:unit` — todos los tests pasan
+
+## Archivos afectados
+
+- `src/lib/date.ts` — nueva función `formatDateShort`
+- `tests/unit/date.test.ts` — tests para `formatDateShort`
+- `src/components/legal/LegalPageLayout.astro` — usar `formatDateShort`
+- `src/pages/blog/[...slug].astro` — `getLangLocale(lang)` en lugar de `'es-ES'`
+- `src/pages/en/blog/[...slug].astro` — `getLangLocale(lang)` en lugar de `'en-US'`
+- `src/components/home/Talks.astro` — `getLangLocale(lang)` en lugar de ternario


### PR DESCRIPTION
Closes #212

## Summary

- Añade `formatDateShort(date)` en `src/lib/date.ts` que devuelve `dd/mm/yyyy` usando UTC accessors (timezone-safe)
- `LegalPageLayout.astro` muestra la fecha formateada; el atributo `datetime` sigue siendo ISO
- Limpia locales hardcodeados (`'es-ES'`, `'en-US'`) en `blog/[...slug].astro` y `Talks.astro` → usan `getLangLocale(lang)`

## Test plan

- [ ] Verificar páginas legales en ES y EN muestran fecha en formato `dd/mm/yyyy`
- [ ] Verificar posts de blog con `updatedDate` muestran la fecha correcta en ambos idiomas
- [ ] `npm run test:unit` — 170 tests pasando
- [ ] `npx astro check` — 0 errores