### PR TITLE
style(nav): iconos de tema y movimiento en contorno (como tools)

### DIFF
--- a/src/components/nav/Nav.astro
+++ b/src/components/nav/Nav.astro
@@ -73,10 +73,10 @@ const workPath = getLocalePath('/work', lang);
                     aria-label={t(lang, 'nav.themeToggle')}
                     title={t(lang, 'nav.themeToggle')}
                 >
-                    <svg aria-hidden="true" class="w-5 h-5 dark:hidden" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <svg aria-hidden="true" class="w-5 h-5 dark:hidden" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z" />
                     </svg>
-                    <svg aria-hidden="true" class="w-5 h-5 hidden dark:block" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <svg aria-hidden="true" class="w-5 h-5 hidden dark:block" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
                     </svg>
                 </button>
@@ -92,10 +92,10 @@ const workPath = getLocalePath('/work', lang);
                 aria-label={t(lang, 'nav.themeToggle')}
                 title={t(lang, 'nav.themeToggle')}
             >
-                <svg aria-hidden="true" class="w-5 h-5 dark:hidden" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <svg aria-hidden="true" class="w-5 h-5 dark:hidden" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z" />
                 </svg>
-                <svg aria-hidden="true" class="w-5 h-5 hidden dark:block" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <svg aria-hidden="true" class="w-5 h-5 hidden dark:block" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
                 </svg>
             </button>

--- a/src/components/shared/MotionToggle.astro
+++ b/src/components/shared/MotionToggle.astro
@@ -34,6 +34,7 @@ const title = lang === 'es' ? 'Reducir movimiento' : 'Reduce motion';
     viewBox="0 0 24 24"
     stroke-width="1.5"
     stroke="currentColor"
+    fill="none"
   >
     <!-- Play/motion icon: three arcs suggesting movement -->
     <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" />
@@ -47,6 +48,7 @@ const title = lang === 'es' ? 'Reducir movimiento' : 'Reduce motion';
     viewBox="0 0 24 24"
     stroke-width="1.5"
     stroke="currentColor"
+    fill="none"
   >
     <!-- Pause icon: two vertical bars = paused/static -->
     <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25v13.5m-7.5-13.5v13.5" />


### PR DESCRIPTION
## Qué

Los iconos del **toggle de tema** (luna/sol) y del **MotionToggle** (quitar efectos) del nav se renderizaban **rellenos** porque los SVG no tenían `fill="none"`. Se añade `fill="none"` para que queden de **contorno**, igual que el selector de tema de [tools.aitorevi.dev](https://tools.aitorevi.dev), que es el aspecto preferido.

## Alcance

- `Nav.astro`: luna/sol de escritorio y móvil.
- `MotionToggle.astro`: iconos de movimiento y pausa.

Solo cambia el render visual (contorno en vez de relleno). Sin cambios de comportamiento, tamaños ni colores.

## Verificación

- Capturas en claro y oscuro: iconos en contorno, coherentes con las tools.
- `npx astro check`: 0 errores.
- `npm run test:unit`: 177 tests verdes.