### PR TITLE
feat(nav): reemplaza menú hamburguesa por barra de navegación inferio…

### DIFF
--- a/src/components/nav/Nav.astro
+++ b/src/components/nav/Nav.astro
@@ -10,6 +10,7 @@ const { alternateUrl } = Astro.props;
 const lang = getLangFromUrl(Astro.url);
 const isEs = lang === 'es';
 const currentPath = Astro.url.pathname;
+const isInHome = currentPath === '/' || currentPath === '/en' || currentPath === '/en/';
 const isInBlog = currentPath.startsWith('/blog') || currentPath.startsWith('/en/blog');
 const isInCv = currentPath.startsWith('/cv') || currentPath.startsWith('/en/cv');
 const isInWork = currentPath.startsWith('/work') || currentPath.startsWith('/en/work');
@@ -84,8 +85,8 @@ const workPath = getLocalePath('/work', lang);
             </div>
         </nav>
 
-        <!-- Mobile: theme toggle + hamburger -->
-        <div class="flex md:hidden items-center gap-2 mx-6">
+        <!-- Mobile: theme toggle only (navigation moved to bottom bar) -->
+        <div class="flex md:hidden items-center mx-6">
             <button
                 id="theme-toggle-mobile"
                 class="min-w-[44px] min-h-[44px] flex items-center justify-center p-2 text-inherit hover:text-accent transition-colors duration-200 cursor-pointer"
@@ -99,77 +100,110 @@ const workPath = getLocalePath('/work', lang);
                     <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
                 </svg>
             </button>
-            <button
-                id="hamburger-toggle"
-                class="min-w-[44px] min-h-[44px] flex items-center justify-center p-2 text-inherit hover:text-accent transition-colors duration-200 cursor-pointer"
-                aria-label={isEs ? 'Abrir menú' : 'Toggle menu'}
-                aria-expanded="false"
-                aria-controls="mobile-menu"
-            >
-                <!-- Hamburger icon -->
-                <svg id="hamburger-open" aria-hidden="true" class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-                </svg>
-                <!-- Close icon -->
-                <svg id="hamburger-close" aria-hidden="true" class="w-6 h-6 hidden" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
-                </svg>
-            </button>
         </div>
-    </div>
-
-    <!-- Mobile menu -->
-    <div id="mobile-menu" class="md:hidden absolute top-14 left-0 w-full bg-white/95 dark:bg-ink-900/95 backdrop-blur-md border-t border-gray-200 dark:border-white/5 shadow-lg transition-all duration-300 ease-in-out overflow-hidden max-h-0 opacity-0">
-        <nav aria-label={isEs ? 'Menú móvil' : 'Mobile menu'} class="flex flex-col p-8 gap-6 text-lg text-center font-mono uppercase tracking-[0.15em]">
-            <a href={workPath}
-               aria-current={isInWork ? 'page' : undefined}
-               class={`cursor-pointer transition ease-linear delay-50 duration-200 ${isInWork ? 'text-accent font-semibold' : 'text-inherit hover:text-accent hover:underline hover:underline-offset-4 hover:decoration-accent/70'}`}>
-                {t(lang, 'nav.work')}
-            </a>
-            <a href={blogPath}
-               aria-current={isInBlog ? 'page' : undefined}
-               class={`cursor-pointer transition ease-linear delay-50 duration-200 ${isInBlog ? 'text-accent font-semibold' : 'text-inherit hover:text-accent hover:underline hover:underline-offset-4 hover:decoration-accent/70'}`}>
-                {t(lang, 'nav.blog')}
-            </a>
-            <a href={cvPath}
-               aria-current={isInCv ? 'page' : undefined}
-               class={`cursor-pointer transition ease-linear delay-50 duration-200 ${isInCv ? 'text-accent font-semibold' : 'text-inherit hover:text-accent hover:underline hover:underline-offset-4 hover:decoration-accent/70'}`}>
-                {t(lang, 'nav.about')}
-            </a>
-            <div role="group" class="flex items-center justify-center gap-1 text-sm font-semibold" aria-label={t(lang, 'nav.langSelect')}>
-                <a href={isEs ? currentPath : alternateUrl}
-                   aria-current={isEs ? 'true' : undefined}
-                   aria-label={t(lang, 'nav.langEs')}
-                   title={t(lang, 'nav.langEs')}
-                   class={`cursor-pointer transition ease-linear delay-50 duration-200 ${isEs ? 'text-accent underline underline-offset-4' : 'text-quaternary hover:text-accent hover:underline hover:underline-offset-4 hover:decoration-accent/70'}`}>
-                    ES
-                </a>
-                <span class="text-quaternary" aria-hidden="true">|</span>
-                <a href={!isEs ? currentPath : alternateUrl}
-                   aria-current={!isEs ? 'true' : undefined}
-                   aria-label={t(lang, 'nav.langEn')}
-                   title={t(lang, 'nav.langEn')}
-                   class={`cursor-pointer transition ease-linear delay-50 duration-200 ${!isEs ? 'text-accent underline underline-offset-4' : 'text-quaternary hover:text-accent hover:underline hover:underline-offset-4 hover:decoration-accent/70'}`}>
-                    EN
-                </a>
-            </div>
-        </nav>
     </div>
 </header>
 
-<script is:inline>
-    function closeMenu() {
-        const menu = document.getElementById('mobile-menu');
-        const hamburgerBtn = document.getElementById('hamburger-toggle');
-        if (!menu || !menu.classList.contains('max-h-80')) return;
-        menu.classList.remove('max-h-80', 'opacity-100');
-        menu.classList.add('max-h-0', 'opacity-0');
-        document.getElementById('hamburger-open').classList.remove('hidden');
-        document.getElementById('hamburger-close').classList.add('hidden');
-        hamburgerBtn.setAttribute('aria-expanded', 'false');
-        hamburgerBtn.focus();
-    }
+<!-- Mobile bottom navigation bar -->
+<nav
+    aria-label={isEs ? 'Navegación principal' : 'Main navigation'}
+    class="md:hidden fixed bottom-0 left-0 right-0 z-10 bg-white/95 dark:bg-ink-900/95 backdrop-blur-md border-t border-gray-200 dark:border-white/5"
+    style="padding-bottom: env(safe-area-inset-bottom)"
+>
+    <ul class="flex items-stretch h-16" role="list">
+        <!-- Home -->
+        <li class="flex-1">
+            <a
+                href={homePath}
+                aria-current={isInHome ? 'page' : undefined}
+                class={`flex flex-col items-center justify-center gap-1 h-full w-full transition-colors duration-150 ${isInHome ? 'text-accent dark:text-accent-violet' : 'text-slate-400 dark:text-slate-500 hover:text-accent dark:hover:text-accent-violet'}`}
+            >
+                <svg aria-hidden="true" class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
+                </svg>
+                <span class="text-[10px] font-mono uppercase tracking-wider leading-none">{t(lang, 'nav.home')}</span>
+            </a>
+        </li>
 
+        <!-- Work -->
+        <li class="flex-1">
+            <a
+                href={workPath}
+                aria-current={isInWork ? 'page' : undefined}
+                class={`flex flex-col items-center justify-center gap-1 h-full w-full transition-colors duration-150 ${isInWork ? 'text-accent dark:text-accent-violet' : 'text-slate-400 dark:text-slate-500 hover:text-accent dark:hover:text-accent-violet'}`}
+            >
+                <svg aria-hidden="true" class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 14.15v4.25c0 1.094-.787 2.036-1.872 2.18-2.087.277-4.216.42-6.378.42s-4.291-.143-6.378-.42c-1.085-.144-1.872-1.086-1.872-2.18v-4.25m16.5 0a2.18 2.18 0 0 0 .75-1.661V8.706c0-1.081-.768-2.015-1.837-2.175a48.114 48.114 0 0 0-3.413-.387m4.5 8.006c-.194.165-.42.295-.673.38A23.978 23.978 0 0 1 12 15.75c-2.648 0-5.195-.429-7.577-1.22a2.016 2.016 0 0 1-.673-.38m0 0A2.18 2.18 0 0 1 3 12.489V8.706c0-1.081.768-2.015 1.837-2.175a48.111 48.111 0 0 1 3.413-.387m7.5 0V5.25A2.25 2.25 0 0 0 13.5 3h-3a2.25 2.25 0 0 0-2.25 2.25v.894m7.5 0a48.667 48.667 0 0 0-7.5 0M12 12.75h.008v.008H12v-.008Z" />
+                </svg>
+                <span class="text-[10px] font-mono uppercase tracking-wider leading-none">{t(lang, 'nav.work')}</span>
+            </a>
+        </li>
+
+        <!-- Blog -->
+        <li class="flex-1">
+            <a
+                href={blogPath}
+                aria-current={isInBlog ? 'page' : undefined}
+                class={`flex flex-col items-center justify-center gap-1 h-full w-full transition-colors duration-150 ${isInBlog ? 'text-accent dark:text-accent-violet' : 'text-slate-400 dark:text-slate-500 hover:text-accent dark:hover:text-accent-violet'}`}
+            >
+                <svg aria-hidden="true" class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+                </svg>
+                <span class="text-[10px] font-mono uppercase tracking-wider leading-none">{t(lang, 'nav.blog')}</span>
+            </a>
+        </li>
+
+        <!-- CV / About -->
+        <li class="flex-1">
+            <a
+                href={cvPath}
+                aria-current={isInCv ? 'page' : undefined}
+                class={`flex flex-col items-center justify-center gap-1 h-full w-full transition-colors duration-150 ${isInCv ? 'text-accent dark:text-accent-violet' : 'text-slate-400 dark:text-slate-500 hover:text-accent dark:hover:text-accent-violet'}`}
+            >
+                <svg aria-hidden="true" class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
+                </svg>
+                <span class="text-[10px] font-mono uppercase tracking-wider leading-none">{t(lang, 'nav.about')}</span>
+            </a>
+        </li>
+
+        <!-- Language switcher -->
+        <li class="flex-1">
+            <div
+                role="group"
+                aria-label={t(lang, 'nav.langSelect')}
+                class="flex flex-col items-center justify-center gap-1 h-full w-full"
+            >
+                <svg aria-hidden="true" class="w-5 h-5 text-slate-400 dark:text-slate-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 0 1 3 12c0-1.605.42-3.113 1.157-4.418" />
+                </svg>
+                <div class="flex items-center gap-1 text-[10px] font-mono font-semibold uppercase tracking-wider leading-none">
+                    <a
+                        href={isEs ? currentPath : alternateUrl}
+                        aria-current={isEs ? 'true' : undefined}
+                        aria-label={t(lang, 'nav.langEs')}
+                        title={t(lang, 'nav.langEs')}
+                        class={`transition-colors duration-150 ${isEs ? 'text-accent dark:text-accent-violet' : 'text-slate-400 dark:text-slate-500'}`}
+                    >
+                        ES
+                    </a>
+                    <span class="text-slate-300 dark:text-slate-600" aria-hidden="true">|</span>
+                    <a
+                        href={!isEs ? currentPath : alternateUrl}
+                        aria-current={!isEs ? 'true' : undefined}
+                        aria-label={t(lang, 'nav.langEn')}
+                        title={t(lang, 'nav.langEn')}
+                        class={`transition-colors duration-150 ${!isEs ? 'text-accent dark:text-accent-violet' : 'text-slate-400 dark:text-slate-500'}`}
+                    >
+                        EN
+                    </a>
+                </div>
+            </div>
+        </li>
+    </ul>
+</nav>
+
+<script is:inline>
     document.addEventListener('click', function(e) {
         // Theme toggle (desktop + mobile)
         const btn = e.target.closest('#theme-toggle, #theme-toggle-mobile');
@@ -178,42 +212,5 @@ const workPath = getLocalePath('/work', lang);
             localStorage.setItem('theme', isDark ? 'dark' : 'light');
             return;
         }
-
-        // Hamburger toggle
-        const hamburger = e.target.closest('#hamburger-toggle');
-        if (hamburger) {
-            const menu = document.getElementById('mobile-menu');
-            const openIcon = document.getElementById('hamburger-open');
-            const closeIcon = document.getElementById('hamburger-close');
-            const isOpen = menu.classList.contains('max-h-0');
-
-            if (isOpen) {
-                menu.classList.remove('max-h-0', 'opacity-0');
-                menu.classList.add('max-h-80', 'opacity-100');
-            } else {
-                menu.classList.remove('max-h-80', 'opacity-100');
-                menu.classList.add('max-h-0', 'opacity-0');
-            }
-            openIcon.classList.toggle('hidden');
-            closeIcon.classList.toggle('hidden');
-            hamburger.setAttribute('aria-expanded', String(isOpen));
-            return;
-        }
-
-        // Close menu when clicking outside
-        const menu = document.getElementById('mobile-menu');
-        const hamburgerBtn = document.getElementById('hamburger-toggle');
-        if (menu && menu.classList.contains('max-h-80') && !menu.contains(e.target) && !hamburgerBtn.contains(e.target)) {
-            menu.classList.remove('max-h-80', 'opacity-100');
-            menu.classList.add('max-h-0', 'opacity-0');
-            document.getElementById('hamburger-open').classList.remove('hidden');
-            document.getElementById('hamburger-close').classList.add('hidden');
-            hamburgerBtn.setAttribute('aria-expanded', 'false');
-        }
-    });
-
-    // Escape closes mobile menu and returns focus to hamburger
-    document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') closeMenu();
     });
 </script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -49,7 +49,7 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `https://www.aitorevi.
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="description" content={description} />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width, viewport-fit=cover" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
 		<!-- Self-hosted fonts: JetBrains Mono (code/accents) + Outfit (display).
@@ -188,6 +188,12 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `https://www.aitorevi.
 	@media (min-width: 768px) {
 		html {
 			scroll-padding-top: 80px;
+		}
+	}
+	/* Bottom nav on mobile: reserve space so footer and content are never hidden under it */
+	@media (max-width: 767px) {
+		body {
+			padding-bottom: calc(4rem + env(safe-area-inset-bottom));
 		}
 	}
 


### PR DESCRIPTION
…r en mobile

El patrón tab-bar es más ergonómico en pantallas grandes de móvil porque los controles quedan al alcance del pulgar sin abrir un drawer. Incluye cinco ítems: Inicio, Work, Blog, CV y selector de idioma, cada uno con icono Heroicon y label en font-mono uppercase. El header mobile queda limpio con solo el logo y el toggle de tema. Se añade viewport-fit=cover y padding-bottom en body para respetar el safe-area de iPhones con notch.