### PR TITLE
refactor(case-study): unifica cards y corrige coherencia de color

### DIFF
--- a/src/components/case-study/ConnectAnalyzerContent.astro
+++ b/src/components/case-study/ConnectAnalyzerContent.astro
@@ -2,9 +2,10 @@
 import Layout from '@/layouts/Layout.astro';
 import Button from '@/components/shared/Button.astro';
 import Tag from '@/components/shared/Tag.astro';
+import StackCard from '@/components/case-study/StackCard.astro';
+import FeatureCard from '@/components/case-study/FeatureCard.astro';
 import { t } from '@/i18n/utils';
 import type { Lang } from '@/i18n/types';
-import DecisionCard from './DecisionCard.astro';
 import LightboxImage from '@/components/shared/LightboxImage.astro';
 
 interface Props {
@@ -45,9 +46,9 @@ const githubIcon =
 
     <!-- Hero -->
     <section class="relative overflow-hidden py-8 pt-24 sm:py-12 sm:pt-28" aria-labelledby="ca-hero">
-      <div class="absolute inset-0 bg-gradient-to-b from-emerald-500/5 to-transparent dark:from-emerald-400/5" aria-hidden="true" />
+      <div class="absolute inset-0 bg-gradient-to-b from-sky-500/5 to-transparent dark:from-sky-400/5" aria-hidden="true" />
       <div class="relative mx-auto max-w-5xl px-6 text-center">
-        <Tag variant="raw" label={t(lang, 'portfolio.connectAnalyzer.tag')} class="border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:border-emerald-400/30 dark:bg-emerald-400/10 dark:text-emerald-400" />
+        <Tag variant="raw" label={t(lang, 'portfolio.connectAnalyzer.tag')} class="border-sky-500/20 bg-sky-500/10 text-sky-700 dark:border-sky-400/30 dark:bg-sky-400/10 dark:text-sky-400" />
         <h1 id="ca-hero" class="mt-6 font-display text-4xl font-bold tracking-tight text-ink-900 dark:text-slate-200 sm:text-5xl">
           {t(lang, 'portfolio.connectAnalyzer.title')}
         </h1>
@@ -55,13 +56,13 @@ const githubIcon =
           {t(lang, 'portfolio.connectAnalyzer.hero.intro')}
         </p>
         <div class="mt-8 flex flex-wrap justify-center gap-3">
-          <Button href={demoUrl} target="_blank" tone="emerald" variant="gradient">
+          <Button href={demoUrl} target="_blank" tone="sky" variant="gradient">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4" aria-hidden="true">
               <path d="M5 12h14M13 5l7 7-7 7" />
             </svg>
             <span>{t(lang, 'portfolio.connectAnalyzer.hero.cta.demo')}</span>
           </Button>
-          <Button href={repoUrl} target="_blank" tone="emerald">
+          <Button href={repoUrl} target="_blank" tone="sky">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-4 w-4" aria-hidden="true">
               <path d={githubIcon} />
             </svg>
@@ -97,14 +98,10 @@ const githubIcon =
         </h2>
         <ul class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
           {solutionKeys.map((key) => (
-            <li class="rounded-xl border border-slate-200 bg-white p-5 dark:border-white/10 dark:bg-white/[0.04]">
-              <h3 class="font-display text-base font-semibold text-ink-900 dark:text-slate-100">
-                {t(lang, `portfolio.connectAnalyzer.solution.${key}`)}
-              </h3>
-              <p class="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-                {t(lang, `portfolio.connectAnalyzer.solution.${key}.desc`)}
-              </p>
-            </li>
+            <FeatureCard
+              title={t(lang, `portfolio.connectAnalyzer.solution.${key}`)}
+              text={t(lang, `portfolio.connectAnalyzer.solution.${key}.desc`)}
+            />
           ))}
         </ul>
       </div>
@@ -121,16 +118,12 @@ const githubIcon =
         </h2>
         <div class="mt-12 grid grid-cols-1 gap-6 sm:grid-cols-3">
           {Object.entries(stack).map(([category, items]) => (
-            <div class="rounded-xl border border-slate-200 bg-slate-50 p-5 dark:border-white/10 dark:bg-white/[0.04]">
-              <h3 class="font-mono text-xs font-semibold uppercase tracking-[0.15em] text-emerald-700 dark:text-emerald-400">
-                {t(lang, `portfolio.connectAnalyzer.stack.${category}`)}
-              </h3>
-              <ul class="mt-3 flex flex-wrap gap-2">
-                {items.map((item) => (
-                  <li><Tag label={item} variant="accent" /></li>
-                ))}
-              </ul>
-            </div>
+            <StackCard
+              title={t(lang, `portfolio.connectAnalyzer.stack.${category}`)}
+              items={items}
+              titleClass="text-sky-700 dark:text-sky-400"
+              tagClass="border-sky-500/20 bg-sky-500/10 text-sky-700 dark:border-sky-400/30 dark:bg-sky-400/10 dark:text-sky-400"
+            />
           ))}
         </div>
       </div>
@@ -147,8 +140,8 @@ const githubIcon =
         </h2>
         <ul class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {decisions.map((key) => (
-            <DecisionCard
-              heading={t(lang, `portfolio.connectAnalyzer.decisions.${key}.heading`)}
+            <FeatureCard
+              title={t(lang, `portfolio.connectAnalyzer.decisions.${key}.heading`)}
               text={t(lang, `portfolio.connectAnalyzer.decisions.${key}.text`)}
             />
           ))}
@@ -189,10 +182,10 @@ const githubIcon =
           {t(lang, 'portfolio.connectAnalyzer.cta.text')}
         </p>
         <div class="mt-8 flex flex-wrap justify-center gap-3">
-          <Button href={postUrl} tone="emerald" variant="gradient">
+          <Button href={postUrl} tone="sky" variant="gradient">
             <span>{t(lang, 'portfolio.connectAnalyzer.cta.post')}</span>
           </Button>
-          <Button href={repoUrl} target="_blank" tone="emerald">
+          <Button href={repoUrl} target="_blank" tone="sky">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-4 w-4" aria-hidden="true">
               <path d={githubIcon} />
             </svg>

--- a/src/components/case-study/DocuAiFlowContent.astro
+++ b/src/components/case-study/DocuAiFlowContent.astro
@@ -2,9 +2,10 @@
 import Layout from '@/layouts/Layout.astro';
 import Button from '@/components/shared/Button.astro';
 import Tag from '@/components/shared/Tag.astro';
+import StackCard from '@/components/case-study/StackCard.astro';
+import FeatureCard from '@/components/case-study/FeatureCard.astro';
 import { t } from '@/i18n/utils';
 import type { Lang } from '@/i18n/types';
-import DecisionCard from './DecisionCard.astro';
 
 interface Props {
   lang: Lang;
@@ -83,14 +84,10 @@ const githubIcon =
         </h2>
         <ul class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
           {solutionKeys.map((key) => (
-            <li class="rounded-xl border border-slate-200 bg-white p-5 dark:border-white/10 dark:bg-white/[0.04]">
-              <h3 class="font-display text-base font-semibold text-ink-900 dark:text-slate-100">
-                {t(lang, `portfolio.docuaiflow.solution.${key}`)}
-              </h3>
-              <p class="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-                {t(lang, `portfolio.docuaiflow.solution.${key}.desc`)}
-              </p>
-            </li>
+            <FeatureCard
+              title={t(lang, `portfolio.docuaiflow.solution.${key}`)}
+              text={t(lang, `portfolio.docuaiflow.solution.${key}.desc`)}
+            />
           ))}
         </ul>
       </div>
@@ -107,16 +104,12 @@ const githubIcon =
         </h2>
         <div class="mt-12 grid grid-cols-1 gap-6 sm:grid-cols-3">
           {Object.entries(stack).map(([category, items]) => (
-            <div class="rounded-xl border border-slate-200 bg-slate-50 p-5 dark:border-white/10 dark:bg-white/[0.04]">
-              <h3 class="font-mono text-xs font-semibold uppercase tracking-[0.15em] text-emerald-700 dark:text-emerald-400">
-                {t(lang, `portfolio.docuaiflow.stack.${category}`)}
-              </h3>
-              <ul class="mt-3 flex flex-wrap gap-2">
-                {items.map((item) => (
-                  <li><Tag label={item} variant="accent" /></li>
-                ))}
-              </ul>
-            </div>
+            <StackCard
+              title={t(lang, `portfolio.docuaiflow.stack.${category}`)}
+              items={items}
+              titleClass="text-emerald-700 dark:text-emerald-400"
+              tagClass="border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:border-emerald-400/30 dark:bg-emerald-400/10 dark:text-emerald-400"
+            />
           ))}
         </div>
       </div>
@@ -133,8 +126,8 @@ const githubIcon =
         </h2>
         <ul class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {decisions.map((key) => (
-            <DecisionCard
-              heading={t(lang, `portfolio.docuaiflow.decisions.${key}.heading`)}
+            <FeatureCard
+              title={t(lang, `portfolio.docuaiflow.decisions.${key}.heading`)}
               text={t(lang, `portfolio.docuaiflow.decisions.${key}.text`)}
             />
           ))}
@@ -156,14 +149,10 @@ const githubIcon =
         </p>
         <ul class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
           {workflowKeys.map((key) => (
-            <li class="rounded-xl border border-emerald-200 bg-emerald-50/50 p-5 dark:border-emerald-400/20 dark:bg-emerald-400/[0.04]">
-              <h3 class="font-display text-base font-semibold text-emerald-800 dark:text-emerald-300">
-                {t(lang, `portfolio.docuaiflow.workflow.${key}`)}
-              </h3>
-              <p class="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-                {t(lang, `portfolio.docuaiflow.workflow.${key}.desc`)}
-              </p>
-            </li>
+            <FeatureCard
+              title={t(lang, `portfolio.docuaiflow.workflow.${key}`)}
+              text={t(lang, `portfolio.docuaiflow.workflow.${key}.desc`)}
+            />
           ))}
         </ul>
       </div>

--- a/src/components/case-study/FeatureCard.astro
+++ b/src/components/case-study/FeatureCard.astro
@@ -7,17 +7,20 @@ interface PostLink {
 }
 
 interface Props {
-  heading: string;
+  /** Already-translated card title. */
+  title: string;
+  /** Already-translated card description. Ignored when `postLink` is set. */
   text?: string;
+  /** Renders an inline link inside the description paragraph. */
   postLink?: PostLink;
 }
 
-const { heading, text, postLink } = Astro.props;
+const { title, text, postLink } = Astro.props;
 ---
 
 <li class="rounded-xl border border-slate-200 bg-white p-5 dark:border-white/10 dark:bg-white/[0.04]">
   <h3 class="font-display text-base font-semibold text-ink-900 dark:text-slate-100">
-    {heading}
+    {title}
   </h3>
   <p class="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
     {postLink ? (

--- a/src/components/case-study/FitkidContent.astro
+++ b/src/components/case-study/FitkidContent.astro
@@ -3,9 +3,10 @@ import { Icon } from 'astro-icon/components';
 import Layout from '@/layouts/Layout.astro';
 import Button from '@/components/shared/Button.astro';
 import Tag from '@/components/shared/Tag.astro';
+import StackCard from '@/components/case-study/StackCard.astro';
+import FeatureCard from '@/components/case-study/FeatureCard.astro';
 import { t } from '@/i18n/utils';
 import type { Lang } from '@/i18n/types';
-import DecisionCard from './DecisionCard.astro';
 import PhoneMockup from './PhoneMockup.astro';
 import LightboxImage from '@/components/shared/LightboxImage.astro';
 
@@ -110,14 +111,10 @@ const screenshots: Screenshot[] = [
         </h2>
         <ul class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
           {solutionKeys.map((key) => (
-            <li class="rounded-xl border border-slate-200 bg-white p-5 dark:border-white/10 dark:bg-white/[0.04]">
-              <h3 class="font-display text-base font-semibold text-ink-900 dark:text-slate-100">
-                {t(lang, `portfolio.fitkid.solution.${key}`)}
-              </h3>
-              <p class="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-                {t(lang, `portfolio.fitkid.solution.${key}.desc`)}
-              </p>
-            </li>
+            <FeatureCard
+              title={t(lang, `portfolio.fitkid.solution.${key}`)}
+              text={t(lang, `portfolio.fitkid.solution.${key}.desc`)}
+            />
           ))}
         </ul>
       </div>
@@ -134,16 +131,12 @@ const screenshots: Screenshot[] = [
         </h2>
         <div class="mt-12 grid grid-cols-1 gap-6 sm:grid-cols-3">
           {Object.entries(stack).map(([category, items]) => (
-            <div class="rounded-xl border border-slate-200 bg-slate-50 p-5 dark:border-white/10 dark:bg-white/[0.04]">
-              <h3 class="font-mono text-xs font-semibold uppercase tracking-[0.15em] text-sky-700 dark:text-sky-400">
-                {t(lang, `portfolio.fitkid.stack.${category}`)}
-              </h3>
-              <ul class="mt-3 flex flex-wrap gap-2">
-                {items.map((item) => (
-                  <li><Tag label={item} variant="accent" /></li>
-                ))}
-              </ul>
-            </div>
+            <StackCard
+              title={t(lang, `portfolio.fitkid.stack.${category}`)}
+              items={items}
+              titleClass="text-blue-700 dark:text-blue-400"
+              tagClass="border-blue-500/20 bg-blue-500/10 text-blue-700 dark:border-blue-400/30 dark:bg-blue-400/10 dark:text-blue-400"
+            />
           ))}
         </div>
       </div>
@@ -160,8 +153,8 @@ const screenshots: Screenshot[] = [
         </h2>
         <ul class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {decisions.map((key) => (
-            <DecisionCard
-              heading={t(lang, `portfolio.fitkid.decisions.${key}.heading`)}
+            <FeatureCard
+              title={t(lang, `portfolio.fitkid.decisions.${key}.heading`)}
               text={t(lang, `portfolio.fitkid.decisions.${key}.text`)}
             />
           ))}
@@ -190,7 +183,7 @@ const screenshots: Screenshot[] = [
                   <PhoneMockup
                     src={`/images/portfolio/fitkid/${img}.webp`}
                     alt={lang === 'es' ? titleEs : titleEn}
-                    glowClass="group-hover:shadow-sky-400/20"
+                    glowClass="group-hover:shadow-blue-400/20"
                   />
                 </div>
               ) : (
@@ -203,7 +196,7 @@ const screenshots: Screenshot[] = [
                 />
               )}
               <div class={flip ? 'md:order-1' : ''}>
-                <span class="font-mono text-[10px] 2xl:text-[12px] uppercase tracking-[0.2em] text-sky-600 dark:text-sky-400">{num}</span>
+                <span class="font-mono text-[10px] 2xl:text-[12px] uppercase tracking-[0.2em] text-blue-600 dark:text-blue-400">{num}</span>
                 <h3 class="mt-2 font-display text-xl font-bold tracking-tight text-ink-900 dark:text-slate-100">
                   {lang === 'es' ? titleEs : titleEn}
                 </h3>

--- a/src/components/case-study/ImsContent.astro
+++ b/src/components/case-study/ImsContent.astro
@@ -2,6 +2,8 @@
 import Layout from '@/layouts/Layout.astro';
 import { t } from '@/i18n/utils';
 import Tag from '@/components/shared/Tag.astro';
+import StackCard from '@/components/case-study/StackCard.astro';
+import FeatureCard from '@/components/case-study/FeatureCard.astro';
 import PhoneMockup from './PhoneMockup.astro';
 import LightboxImage from '@/components/shared/LightboxImage.astro';
 
@@ -56,14 +58,10 @@ const stack = {
         </h2>
         <ul class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
           {featureKeys.map((key) => (
-            <li class="rounded-xl border border-slate-200 bg-slate-50 p-5 dark:border-white/10 dark:bg-white/[0.04]">
-              <h3 class="font-display text-base font-semibold text-ink-900 dark:text-slate-100">
-                {t(lang, `portfolio.ims.feat.${key}.title`)}
-              </h3>
-              <p class="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-                {t(lang, `portfolio.ims.feat.${key}`)}
-              </p>
-            </li>
+            <FeatureCard
+              title={t(lang, `portfolio.ims.feat.${key}.title`)}
+              text={t(lang, `portfolio.ims.feat.${key}`)}
+            />
           ))}
         </ul>
       </div>
@@ -80,16 +78,10 @@ const stack = {
         </h2>
         <div class="mt-12 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
           {Object.entries(stack).map(([category, items]) => (
-            <div class="rounded-xl border border-slate-200 bg-white p-5 dark:border-white/10 dark:bg-white/[0.04]">
-              <h3 class="font-mono text-xs font-semibold uppercase tracking-[0.15em] text-secondary dark:text-accent-blue">
-                {t(lang, `portfolio.ims.stack.${category}`)}
-              </h3>
-              <ul class="mt-3 flex flex-wrap gap-2">
-                {items.map((item) => (
-                  <li><Tag label={item} variant="accent" /></li>
-                ))}
-              </ul>
-            </div>
+            <StackCard
+              title={t(lang, `portfolio.ims.stack.${category}`)}
+              items={items}
+            />
           ))}
         </div>
       </div>

--- a/src/components/case-study/OpencleanerContent.astro
+++ b/src/components/case-study/OpencleanerContent.astro
@@ -3,9 +3,10 @@ import { Icon } from 'astro-icon/components';
 import Layout from '@/layouts/Layout.astro';
 import Button from '@/components/shared/Button.astro';
 import Tag from '@/components/shared/Tag.astro';
+import StackCard from '@/components/case-study/StackCard.astro';
+import FeatureCard from '@/components/case-study/FeatureCard.astro';
 import { t } from '@/i18n/utils';
 import type { Lang } from '@/i18n/types';
-import DecisionCard from './DecisionCard.astro';
 import LightboxImage from '@/components/shared/LightboxImage.astro';
 
 interface Props {
@@ -46,7 +47,7 @@ const decisions = ['cleanarch', 'nocodesign', 'trash'] as const;
           {t(lang, 'portfolio.opencleaner.hero.intro')}
         </p>
         <div class="mt-8 flex justify-center">
-          <Button href={repoUrl} target="_blank" tone="blue">
+          <Button href={repoUrl} target="_blank" tone="zinc">
             <Icon name="github" class="h-4 w-4" aria-hidden="true" />
             <span>{t(lang, 'portfolio.opencleaner.hero.cta.repo')}</span>
           </Button>
@@ -80,14 +81,10 @@ const decisions = ['cleanarch', 'nocodesign', 'trash'] as const;
         </h2>
         <ul class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
           {solutionKeys.map((key) => (
-            <li class="rounded-xl border border-slate-200 bg-white p-5 dark:border-white/10 dark:bg-white/[0.04]">
-              <h3 class="font-display text-base font-semibold text-ink-900 dark:text-slate-100">
-                {t(lang, `portfolio.opencleaner.solution.${key}`)}
-              </h3>
-              <p class="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-                {t(lang, `portfolio.opencleaner.solution.${key}.desc`)}
-              </p>
-            </li>
+            <FeatureCard
+              title={t(lang, `portfolio.opencleaner.solution.${key}`)}
+              text={t(lang, `portfolio.opencleaner.solution.${key}.desc`)}
+            />
           ))}
         </ul>
       </div>
@@ -104,16 +101,12 @@ const decisions = ['cleanarch', 'nocodesign', 'trash'] as const;
         </h2>
         <div class="mt-12 grid grid-cols-1 gap-6 sm:grid-cols-3">
           {Object.entries(stack).map(([category, items]) => (
-            <div class="rounded-xl border border-slate-200 bg-slate-50 p-5 dark:border-white/10 dark:bg-white/[0.04]">
-              <h3 class="font-mono text-xs font-semibold uppercase tracking-[0.15em] text-zinc-700 dark:text-zinc-400">
-                {t(lang, `portfolio.opencleaner.stack.${category}`)}
-              </h3>
-              <ul class="mt-3 flex flex-wrap gap-2">
-                {items.map((item) => (
-                  <li><Tag label={item} variant="accent" /></li>
-                ))}
-              </ul>
-            </div>
+            <StackCard
+              title={t(lang, `portfolio.opencleaner.stack.${category}`)}
+              items={items}
+              titleClass="text-zinc-700 dark:text-zinc-400"
+              tagClass="border-zinc-500/20 bg-zinc-500/10 text-zinc-700 dark:border-zinc-400/30 dark:bg-zinc-400/10 dark:text-zinc-400"
+            />
           ))}
         </div>
       </div>
@@ -130,8 +123,8 @@ const decisions = ['cleanarch', 'nocodesign', 'trash'] as const;
         </h2>
         <ul class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {decisions.map((key) => (
-            <DecisionCard
-              heading={t(lang, `portfolio.opencleaner.decisions.${key}.heading`)}
+            <FeatureCard
+              title={t(lang, `portfolio.opencleaner.decisions.${key}.heading`)}
               text={t(lang, `portfolio.opencleaner.decisions.${key}.text`)}
             />
           ))}
@@ -168,7 +161,7 @@ const decisions = ['cleanarch', 'nocodesign', 'trash'] as const;
           {t(lang, 'portfolio.opencleaner.cta.text')}
         </p>
         <div class="mt-8 flex justify-center">
-          <Button href={repoUrl} target="_blank" tone="blue">
+          <Button href={repoUrl} target="_blank" tone="zinc">
             <Icon name="github" class="h-4 w-4" aria-hidden="true" />
             <span>{t(lang, 'portfolio.opencleaner.cta.repo')}</span>
           </Button>

--- a/src/components/case-study/SelfContent.astro
+++ b/src/components/case-study/SelfContent.astro
@@ -8,7 +8,7 @@ import type { Lang } from '@/i18n/types';
 import { fetchBuildStats } from '@/lib/build-time/build-stats';
 import StatCard from '@/components/shared/StatCard.astro';
 import SectionHeader from '@/components/shared/SectionHeader.astro';
-import DecisionCard from './DecisionCard.astro';
+import FeatureCard from './FeatureCard.astro';
 import StackCategory from './StackCategory.astro';
 import ScoreBadge from './ScoreBadge.astro';
 
@@ -187,8 +187,8 @@ const stack: Record<'frontend' | 'content' | 'infra' | 'testing', TechItem[]> = 
               ? t(lang, 'a11y.url')
               : buildBlogPostPath(postSlug);
             return (
-              <DecisionCard
-                heading={t(lang, `portfolio.self.decisions.${key}.heading`)}
+              <FeatureCard
+                title={t(lang, `portfolio.self.decisions.${key}.heading`)}
                 text={!hasLink ? t(lang, `portfolio.self.decisions.${key}.text`) : undefined}
                 postLink={hasLink ? {
                   href: linkHref,

--- a/src/components/case-study/StackCard.astro
+++ b/src/components/case-study/StackCard.astro
@@ -1,0 +1,45 @@
+---
+import Tag from '@/components/shared/Tag.astro';
+
+interface Props {
+  /** Already-translated category title. */
+  title: string;
+  items: string[];
+  /** Accent color classes for the title (per case study). The leading dot
+   *  inherits this color via `bg-current`. */
+  titleClass?: string;
+  /** Per-case-study color classes for the tags. When omitted, tags fall back
+   *  to the global accent (violet) via the `accent` variant. */
+  tagClass?: string;
+}
+
+const {
+  title,
+  items,
+  titleClass = 'text-secondary dark:text-accent-violet',
+  tagClass,
+} = Astro.props;
+---
+
+<div class="rounded-xl border border-slate-200 bg-slate-50 p-5 dark:border-white/10 dark:bg-white/[0.04]">
+  <h3
+    class:list={[
+      'flex items-center gap-2 font-mono text-xs font-semibold uppercase tracking-[0.15em]',
+      titleClass,
+    ]}
+  >
+    <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-current" aria-hidden="true" />
+    {title}
+  </h3>
+  <ul class="mt-3 flex flex-wrap gap-2">
+    {items.map((item) => (
+      <li>
+        {tagClass ? (
+          <Tag label={item} variant="raw" class={tagClass} />
+        ) : (
+          <Tag label={item} variant="accent" />
+        )}
+      </li>
+    ))}
+  </ul>
+</div>

--- a/src/components/case-study/ToolsContent.astro
+++ b/src/components/case-study/ToolsContent.astro
@@ -2,9 +2,10 @@
 import Layout from '@/layouts/Layout.astro';
 import Button from '@/components/shared/Button.astro';
 import Tag from '@/components/shared/Tag.astro';
+import StackCard from '@/components/case-study/StackCard.astro';
+import FeatureCard from '@/components/case-study/FeatureCard.astro';
 import { t } from '@/i18n/utils';
 import type { Lang } from '@/i18n/types';
-import DecisionCard from './DecisionCard.astro';
 import LightboxImage from '@/components/shared/LightboxImage.astro';
 
 interface Props {
@@ -96,14 +97,10 @@ const githubIcon =
         </h2>
         <ul class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
           {solutionKeys.map((key) => (
-            <li class="rounded-xl border border-slate-200 bg-white p-5 dark:border-white/10 dark:bg-white/[0.04]">
-              <h3 class="font-display text-base font-semibold text-ink-900 dark:text-slate-100">
-                {t(lang, `portfolio.tools.solution.${key}`)}
-              </h3>
-              <p class="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-                {t(lang, `portfolio.tools.solution.${key}.desc`)}
-              </p>
-            </li>
+            <FeatureCard
+              title={t(lang, `portfolio.tools.solution.${key}`)}
+              text={t(lang, `portfolio.tools.solution.${key}.desc`)}
+            />
           ))}
         </ul>
       </div>
@@ -120,16 +117,12 @@ const githubIcon =
         </h2>
         <div class="mt-12 grid grid-cols-1 gap-6 sm:grid-cols-3">
           {Object.entries(stack).map(([category, items]) => (
-            <div class="rounded-xl border border-slate-200 bg-slate-50 p-5 dark:border-white/10 dark:bg-white/[0.04]">
-              <h3 class="font-mono text-xs font-semibold uppercase tracking-[0.15em] text-violet-700 dark:text-accent-violet">
-                {t(lang, `portfolio.tools.stack.${category}`)}
-              </h3>
-              <ul class="mt-3 flex flex-wrap gap-2">
-                {items.map((item) => (
-                  <li><Tag label={item} variant="accent" /></li>
-                ))}
-              </ul>
-            </div>
+            <StackCard
+              title={t(lang, `portfolio.tools.stack.${category}`)}
+              items={items}
+              titleClass="text-violet-700 dark:text-accent-violet"
+              tagClass="border-violet-500/20 bg-violet-500/10 text-violet-700 dark:border-accent-violet/30 dark:bg-accent-violet/10 dark:text-accent-violet"
+            />
           ))}
         </div>
       </div>
@@ -146,8 +139,8 @@ const githubIcon =
         </h2>
         <ul class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {decisions.map((key) => (
-            <DecisionCard
-              heading={t(lang, `portfolio.tools.decisions.${key}.heading`)}
+            <FeatureCard
+              title={t(lang, `portfolio.tools.decisions.${key}.heading`)}
               text={t(lang, `portfolio.tools.decisions.${key}.text`)}
             />
           ))}

--- a/src/components/shared/buttonStyles.ts
+++ b/src/components/shared/buttonStyles.ts
@@ -1,4 +1,4 @@
-export type ButtonTone = 'blue' | 'violet' | 'brand' | 'emerald';
+export type ButtonTone = 'blue' | 'violet' | 'brand' | 'emerald' | 'zinc' | 'sky';
 export type ButtonVariant = 'ghost' | 'gradient';
 export type ButtonType = 'button' | 'submit' | 'reset';
 
@@ -27,6 +27,8 @@ const TONE_RING: Record<ButtonTone, string> = {
   violet: 'focus-visible:ring-accent-violet',
   brand: 'focus-visible:ring-secondary dark:focus-visible:ring-accent-blue',
   emerald: 'focus-visible:ring-accent-emerald',
+  zinc: 'focus-visible:ring-zinc-500',
+  sky: 'focus-visible:ring-accent-sky',
 };
 
 const GHOST_BY_TONE: Record<ButtonTone, string> = {
@@ -37,6 +39,10 @@ const GHOST_BY_TONE: Record<ButtonTone, string> = {
     'border border-secondary/40 bg-secondary/5 text-secondary hover:border-secondary/70 hover:bg-secondary/15 hover:shadow-[0_0_30px_rgba(94,58,238,0.2)] dark:border-accent-blue/40 dark:bg-accent-blue/10 dark:text-accent-blue dark:hover:border-accent-blue/70 dark:hover:bg-accent-blue/20 dark:hover:shadow-[0_0_40px_rgba(96,165,250,0.3)]',
   emerald:
     'border border-accent-emerald/40 bg-accent-emerald/5 text-emerald-700 dark:text-accent-emerald hover:border-accent-emerald/70 hover:bg-accent-emerald/15 hover:shadow-[0_0_30px_rgba(16,185,129,0.2)] dark:bg-accent-emerald/10 dark:hover:bg-accent-emerald/20 dark:hover:shadow-[0_0_40px_rgba(16,185,129,0.3)]',
+  zinc:
+    'border border-zinc-500/40 bg-zinc-500/5 text-zinc-700 dark:text-zinc-300 hover:border-zinc-500/70 hover:bg-zinc-500/15 hover:shadow-[0_0_30px_rgba(113,113,122,0.2)] dark:bg-zinc-400/10 dark:hover:bg-zinc-400/20 dark:hover:shadow-[0_0_40px_rgba(161,161,170,0.3)]',
+  sky:
+    'border border-accent-sky/40 bg-accent-sky/5 text-sky-700 dark:text-accent-sky hover:border-accent-sky/70 hover:bg-accent-sky/15 hover:shadow-[0_0_30px_rgba(56,189,248,0.2)] dark:bg-accent-sky/10 dark:hover:bg-accent-sky/20 dark:hover:shadow-[0_0_40px_rgba(56,189,248,0.3)]',
 };
 
 const GRADIENT_BY_TONE: Record<ButtonTone, string> = {
@@ -47,6 +53,10 @@ const GRADIENT_BY_TONE: Record<ButtonTone, string> = {
     'border border-secondary/50 bg-gradient-to-r from-secondary/10 to-accent-violet/10 text-secondary hover:border-secondary/80 hover:from-secondary/20 hover:to-accent-violet/20 hover:shadow-[0_10px_30px_-10px_rgba(94,58,238,0.4)] dark:border-accent-blue/40 dark:from-accent-blue/15 dark:to-accent-violet/15 dark:text-accent-blue dark:hover:border-accent-blue/80 dark:hover:from-accent-blue/25 dark:hover:to-accent-violet/25 dark:hover:shadow-[0_0_40px_rgba(96,165,250,0.3)]',
   emerald:
     'border border-accent-emerald/50 bg-gradient-to-r from-accent-emerald/10 to-accent-emerald/20 text-emerald-700 dark:text-accent-emerald hover:border-accent-emerald/80 hover:from-accent-emerald/20 hover:to-accent-emerald/30 hover:shadow-[0_10px_30px_-10px_rgba(16,185,129,0.4)] dark:from-accent-emerald/15 dark:to-accent-emerald/25',
+  zinc:
+    'border border-zinc-500/50 bg-gradient-to-r from-zinc-500/10 to-zinc-500/20 text-zinc-700 dark:text-zinc-300 hover:border-zinc-500/80 hover:from-zinc-500/20 hover:to-zinc-500/30 hover:shadow-[0_10px_30px_-10px_rgba(113,113,122,0.4)] dark:from-zinc-400/15 dark:to-zinc-400/25',
+  sky:
+    'border border-accent-sky/50 bg-gradient-to-r from-accent-sky/10 to-accent-sky/20 text-sky-700 dark:text-accent-sky hover:border-accent-sky/80 hover:from-accent-sky/20 hover:to-accent-sky/30 hover:shadow-[0_10px_30px_-10px_rgba(56,189,248,0.4)] dark:from-accent-sky/15 dark:to-accent-sky/25',
 };
 
 export function buildButtonClasses(opts: BuildClassesOpts = {}): string {

--- a/src/components/work/WorkCinematic.astro
+++ b/src/components/work/WorkCinematic.astro
@@ -60,8 +60,8 @@ const accentMap: Record<string, { text: string; textDark: string; bg: string; ri
   violet:  { text: 'text-violet-700 dark:text-accent-violet',   textDark: 'text-accent-violet',  bg: 'bg-accent-violet',  ring: 'ring-accent-violet/40',  glow: 'from-accent-violet/30', border: 'border-accent-violet/40',  borderLight: 'border-accent-violet/40', bgLight: 'bg-accent-violet/5',  buttonTone: 'violet', sectionVar: '--color-section-violet' },
   blue:    { text: 'text-blue-700 dark:text-accent-blue',       textDark: 'text-accent-blue',    bg: 'bg-accent-blue',    ring: 'ring-accent-blue/40',    glow: 'from-accent-blue/30',   border: 'border-accent-blue/40',    borderLight: 'border-accent-blue/40',   bgLight: 'bg-accent-blue/5',    buttonTone: 'blue',   sectionVar: '--color-section-blue' },
   emerald: { text: 'text-emerald-700 dark:text-accent-emerald', textDark: 'text-accent-emerald', bg: 'bg-accent-emerald', ring: 'ring-accent-emerald/40', glow: 'from-accent-emerald/25', border: 'border-accent-emerald/40', borderLight: 'border-accent-emerald/40', bgLight: 'bg-accent-emerald/5', buttonTone: 'emerald', sectionVar: '--color-section-emerald' },
-  sky:     { text: 'text-sky-700 dark:text-accent-sky',         textDark: 'text-accent-sky',     bg: 'bg-accent-sky',     ring: 'ring-accent-sky/40',     glow: 'from-accent-sky/25',    border: 'border-accent-sky/40',     borderLight: 'border-accent-sky/40',    bgLight: 'bg-accent-sky/5',     buttonTone: 'blue',   sectionVar: '--color-section-sky' },
-  zinc:    { text: 'text-zinc-700 dark:text-zinc-300',          textDark: 'text-zinc-300',       bg: 'bg-zinc-500',       ring: 'ring-zinc-500/40',       glow: 'from-zinc-500/20',      border: 'border-zinc-500/40',       borderLight: 'border-zinc-300',         bgLight: 'bg-zinc-50',          buttonTone: 'blue',   sectionVar: '--color-section-blue' },
+  sky:     { text: 'text-sky-700 dark:text-accent-sky',         textDark: 'text-accent-sky',     bg: 'bg-accent-sky',     ring: 'ring-accent-sky/40',     glow: 'from-accent-sky/25',    border: 'border-accent-sky/40',     borderLight: 'border-accent-sky/40',    bgLight: 'bg-accent-sky/5',     buttonTone: 'sky',    sectionVar: '--color-section-sky' },
+  zinc:    { text: 'text-zinc-700 dark:text-zinc-300',          textDark: 'text-zinc-300',       bg: 'bg-zinc-500',       ring: 'ring-zinc-500/40',       glow: 'from-zinc-500/20',      border: 'border-zinc-500/40',       borderLight: 'border-zinc-300',         bgLight: 'bg-zinc-50',          buttonTone: 'zinc',   sectionVar: '--color-section-zinc' },
 };
 
 const ctaLabel = t(lang, 'home.work.cta.case');
@@ -293,6 +293,11 @@ const externalLabel = t(lang, 'home.work.cta.external');
 </style>
 
 <style is:global>
+  /* Section hover color for the zinc accent — mirrors the --color-section-*
+     tokens in tokens.css, which has no zinc entry. */
+  :root { --color-section-zinc: 63 63 70; }   /* zinc-700 #3f3f46 */
+  .dark { --color-section-zinc: 212 212 216; } /* zinc-300 #d4d4d8 */
+
   /* scroll-snap-type must live on the scroll container (body).
      scroll-padding-top offsets the sticky nav so sections snap below it. */
   body:has(.work-cinematic) {

--- a/src/content/projects/opencleaner.yaml
+++ b/src/content/projects/opencleaner.yaml
@@ -10,7 +10,7 @@ stack:
   - React 19
   - TypeScript
   - Clean Architecture
-accent: emerald
+accent: zinc
 hrefEs: /work/opencleaner
 hrefEn: /en/work/opencleaner
 external: false

--- a/src/pages/styleguide.astro
+++ b/src/pages/styleguide.astro
@@ -4,7 +4,7 @@ import Button from '@/components/shared/Button.astro';
 import Tag from '@/components/shared/Tag.astro';
 import SectionHeader from '@/components/shared/SectionHeader.astro';
 import StatCard from '@/components/shared/StatCard.astro';
-import DecisionCard from '@/components/case-study/DecisionCard.astro';
+import FeatureCard from '@/components/case-study/FeatureCard.astro';
 import ScoreBadge from '@/components/case-study/ScoreBadge.astro';
 import { Icon } from 'astro-icon/components';
 
@@ -536,16 +536,16 @@ console.log(greeting('aitorevi'));</code></pre>
         </div>
       </div>
 
-      <!-- DecisionCard -->
+      <!-- FeatureCard -->
       <div class="space-y-4">
-        <h3 class="font-mono text-xs uppercase tracking-widest text-fg-muted border-b border-slate-200 dark:border-white/10 pb-2">DecisionCard</h3>
+        <h3 class="font-mono text-xs uppercase tracking-widest text-fg-muted border-b border-slate-200 dark:border-white/10 pb-2">FeatureCard</h3>
         <ul class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <DecisionCard
-            heading="SSG con Astro"
+          <FeatureCard
+            title="SSG con Astro"
             text="Genera HTML estático en build time. Sin JS por defecto — solo se hidrata lo que lo necesita explícitamente."
           />
-          <DecisionCard
-            heading="Tests que usan blog posts reales"
+          <FeatureCard
+            title="Tests que usan blog posts reales"
             postLink={{
               href: '/blog/ejemplo',
               label: 'ver el post',
@@ -555,7 +555,7 @@ console.log(greeting('aitorevi'));</code></pre>
           />
         </ul>
         <div class="rounded-xl bg-slate-50 dark:bg-white/5 p-4 font-mono text-xs text-fg-muted">
-          {'<DecisionCard heading="SSG con Astro" text="..." />'}
+          {'<FeatureCard title="SSG con Astro" text="..." />'}
         </div>
       </div>
 


### PR DESCRIPTION
## Resumen

Refactor de las cards de los casos de estudio + corrección de coherencia de color por sección.

### Componentes
- **`StackCard`**: card de la sección de stack, con punto inicial en el título y color por caso de estudio (`titleClass` + `tagClass`). Los tags pasan de violeta fijo al acento de cada caso.
- **`FeatureCard`**: card "título + descripción" (solución / features / decisiones), neutra y uniforme. Absorbe el antiguo `DecisionCard` vía `postLink` opcional → **`DecisionCard` eliminado**.
- La **styleguide** documenta ahora `FeatureCard`.

### Sistema de botones
- Nuevos tonos **`sky`** y **`zinc`** en `Button` (antes solo `blue | violet | brand | emerald`).

### Coherencia de color por caso
| Caso | Cambio |
|---|---|
| DocuAiFlow | sección "Construido con Claude Code" deja de ir verde (card neutra) |
| ConnectAnalyzer | emerald → **sky** (su accent) |
| Fitkid | sky → **blue** (su accent) |
| Opencleaner | dato `accent: emerald` → **zinc** + botones/hover zinc en el listado |
| IMS | título del stack ya no es azul en dark; fondo de cards normalizado |

### Listado `/work`
- `zinc` usa `buttonTone: zinc` y nuevo `--color-section-zinc` (en el `<style is:global>`, ya que `tokens.css` no tiene entrada zinc) → el hover del título de opencleaner deja de ser azul.
- `sky` usa `buttonTone: sky` → botones de "visitar sitio" de irph y connect-analyzer toman su color.

## Verificación
- `astro check`: 0 errores, 0 warnings.
- Tests de Button: 16/16 ✅.

> Nota: `src/styles/tokens.css` está bloqueado por permisos, por eso el token `--color-section-zinc` vive en el `<style is:global>` de `WorkCinematic.astro`. Si se prefiere, puede moverse a `tokens.css` junto a los demás `--color-section-*`.