### PR TITLE
docs(legal): añade Cloudflare Turnstile a la política de privacidad

### DIFF
--- a/src/pages/en/privacy.astro
+++ b/src/pages/en/privacy.astro
@@ -6,7 +6,7 @@ import LegalPageLayout from '@/components/legal/LegalPageLayout.astro';
   lang="en"
   title="Privacy Policy"
   description="Privacy policy for aitorevi.dev: what personal data we process, processors involved, legal basis, and how to exercise your rights."
-  updatedDate="2026-04-22"
+  updatedDate="2026-07-07"
 >
   <p>
     This page explains what personal data is processed through aitorevi.dev, the purposes,
@@ -43,11 +43,23 @@ import LegalPageLayout from '@/components/legal/LegalPageLayout.astro';
     abuse. A hash of your IP is stored temporarily in Upstash Redis for up to 1 hour.
   </p>
 
+  <h3>2.4 Anti-spam protection (Cloudflare Turnstile)</h3>
+  <p>
+    To verify that the form is submitted by a person and not a bot, the site uses
+    <strong>Cloudflare Turnstile</strong>, an anti-spam system that runs invisibly, with no
+    visual challenges and no advertising-tracking cookies. During verification, Cloudflare
+    may process technical data such as your IP address and browser signals. This processing
+    is governed by Cloudflare's
+    <a href="https://www.cloudflare.com/turnstile-privacy-policy/" target="_blank" rel="noopener noreferrer">Turnstile Privacy Addendum</a>,
+    supplemental to its Privacy Policy.
+  </p>
+
   <h2>3. Legal basis</h2>
   <ul>
     <li><strong>Contact form</strong>: your consent when submitting the message (GDPR art. 6.1.a).</li>
     <li><strong>Analytics</strong>: consent via the cookie banner (GDPR art. 6.1.a and LSSI-CE art. 22).</li>
     <li><strong>Rate limiting</strong>: legitimate interest in preventing abuse (GDPR art. 6.1.f).</li>
+    <li><strong>Anti-spam protection (Turnstile)</strong>: legitimate interest in preventing automated submissions and form abuse (GDPR art. 6.1.f).</li>
   </ul>
 
   <h2>4. Processors and recipients</h2>
@@ -57,6 +69,7 @@ import LegalPageLayout from '@/components/legal/LegalPageLayout.astro';
     <li><strong>Google LLC</strong> — Google Analytics 4 (only with consent) and Google Search Console (aggregated indexing data only, no personal data). US-based, SCCs.</li>
     <li><strong>Resend, Inc.</strong> — transactional email sending (contact form confirmation). US-based, SCCs.</li>
     <li><strong>Upstash Inc.</strong> — ephemeral storage of IP hashes for rate limiting. US-based, SCCs.</li>
+    <li><strong>Cloudflare, Inc.</strong> — anti-spam form verification via Turnstile. US-based, SCCs.</li>
     <li><strong>GitHub, Inc.</strong> — source code and editable content storage (via Keystatic). US-based, SCCs.</li>
   </ul>
   <p>

--- a/src/pages/privacidad.astro
+++ b/src/pages/privacidad.astro
@@ -6,7 +6,7 @@ import LegalPageLayout from '@/components/legal/LegalPageLayout.astro';
   lang="es"
   title="Política de Privacidad"
   description="Política de privacidad de aitorevi.dev: datos que tratamos, encargados, base legal y cómo ejercer tus derechos."
-  updatedDate="2026-04-22"
+  updatedDate="2026-07-07"
 >
   <p>
     En esta página se explica qué datos personales se tratan a través de aitorevi.dev,
@@ -46,11 +46,23 @@ import LegalPageLayout from '@/components/legal/LegalPageLayout.astro';
     durante como máximo 1 hora.
   </p>
 
+  <h3>2.4 Protección anti-spam (Cloudflare Turnstile)</h3>
+  <p>
+    Para verificar que quien envía el formulario es una persona y no un bot, el sitio usa
+    <strong>Cloudflare Turnstile</strong>, un sistema anti-spam que funciona de forma
+    invisible, sin retos visuales ni cookies de seguimiento publicitario. Durante la
+    verificación, Cloudflare puede tratar datos técnicos como tu dirección IP y señales del
+    navegador. Este tratamiento se rige por el
+    <a href="https://www.cloudflare.com/turnstile-privacy-policy/" target="_blank" rel="noopener noreferrer">Turnstile Privacy Addendum</a>
+    de Cloudflare, complementario a su Política de Privacidad.
+  </p>
+
   <h2>3. Base legal</h2>
   <ul>
     <li><strong>Formulario de contacto</strong>: consentimiento al enviar el mensaje (art. 6.1.a RGPD).</li>
     <li><strong>Analítica</strong>: consentimiento mediante banner de cookies (art. 6.1.a RGPD y art. 22 LSSI-CE).</li>
     <li><strong>Rate limiting</strong>: interés legítimo en prevenir usos abusivos (art. 6.1.f RGPD).</li>
+    <li><strong>Protección anti-spam (Turnstile)</strong>: interés legítimo en prevenir el envío automatizado y el abuso del formulario (art. 6.1.f RGPD).</li>
   </ul>
 
   <h2>4. Encargados y cesionarios</h2>
@@ -60,6 +72,7 @@ import LegalPageLayout from '@/components/legal/LegalPageLayout.astro';
     <li><strong>Google LLC</strong> — Google Analytics 4 (solo con consent) y Google Search Console (solo datos agregados de indexación, no personales). EE. UU., CCT.</li>
     <li><strong>Resend, Inc.</strong> — envío transaccional del email de confirmación del formulario de contacto. EE. UU., CCT.</li>
     <li><strong>Upstash Inc.</strong> — almacenamiento efímero de hashes de IP para rate limiting. EE. UU., CCT.</li>
+    <li><strong>Cloudflare, Inc.</strong> — verificación anti-spam del formulario mediante Turnstile. EE. UU., CCT.</li>
     <li><strong>GitHub, Inc.</strong> — almacenamiento del código fuente y, a través de Keystatic, del contenido editable. EE. UU., CCT.</li>
   </ul>
   <p>


### PR DESCRIPTION
## Contexto

El formulario usa **Cloudflare Turnstile** en modo **Invisible**. Cloudflare exige, como condición de uso de ese modo, **referenciar el Turnstile Privacy Addendum en la política de privacidad**. Este PR cumple ese requisito y encaja con la cláusula RGPD existente.

## Cambios (ES y EN)
- Nueva subsección **2.4 Protección anti-spam (Cloudflare Turnstile)** con enlace al [Turnstile Privacy Addendum](https://www.cloudflare.com/turnstile-privacy-policy/).
- Nueva entrada en **base legal**: interés legítimo (art. 6.1.f RGPD).
- **Cloudflare, Inc.** añadido a la lista de encargados (EE. UU., CCT).
- Fecha de última actualización → 2026-07-07.

## Verificación
- `npx astro check` → 0 errores.
- Enlace al Addendum verificado (HTTP 200).