### PR TITLE
feat(contact): spinner en el botón al enviar el formulario

### DIFF
--- a/src/components/home/ContactSection.astro
+++ b/src/components/home/ContactSection.astro
@@ -13,6 +13,7 @@ import { Icon } from 'astro-icon/components';
 import type { Lang } from '@/i18n/types';
 import { t } from '@/i18n/utils';
 import Button from '@/components/shared/Button.astro';
+import Spinner from '@/components/shared/Spinner.astro';
 import SectionHeader from '@/components/shared/SectionHeader.astro';
 
 interface Props {
@@ -203,8 +204,10 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY ?? '';
           <span>{t(lang, 'home.contact.submit')}</span>
           <span
             aria-hidden="true"
+            data-submit-arrow
             class="transition-transform duration-300 group-hover:translate-x-1"
           >→</span>
+          <Spinner class="hidden ml-1" data-submit-spinner />
         </Button>
       </div>
 
@@ -333,7 +336,19 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY ?? '';
 
     const status = form.querySelector<HTMLElement>('[data-contact-status]');
     const submitBtn = form.querySelector<HTMLButtonElement>('button[type="submit"]');
+    const submitArrow = form.querySelector<HTMLElement>('[data-submit-arrow]');
+    const submitSpinner = form.querySelector<HTMLElement>('[data-submit-spinner]');
     const turnstileEl = form.querySelector<HTMLElement>('[data-turnstile]');
+
+    // Toggle the button's loading state: disable it and swap the arrow for a spinner.
+    const setLoading = (loading: boolean) => {
+      if (submitBtn) {
+        submitBtn.disabled = loading;
+        submitBtn.setAttribute('aria-busy', String(loading));
+      }
+      submitArrow?.classList.toggle('hidden', loading);
+      submitSpinner?.classList.toggle('hidden', !loading);
+    };
 
     // Render now if the script is loaded; otherwise the global onload callback handles it.
     if (turnstileEl) renderTurnstile(turnstileEl);
@@ -431,7 +446,7 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY ?? '';
         return;
       }
 
-      if (submitBtn) submitBtn.disabled = true;
+      setLoading(true);
 
       try {
         const res = await fetch('/api/contact', {
@@ -454,7 +469,7 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY ?? '';
       } catch {
         showStatus(msgs.networkError, true);
       } finally {
-        if (submitBtn) submitBtn.disabled = false;
+        setLoading(false);
         // Turnstile tokens are single-use — reset so the next attempt gets a fresh one.
         getTurnstile()?.reset(turnstileWidgetId);
       }

--- a/src/components/shared/Spinner.astro
+++ b/src/components/shared/Spinner.astro
@@ -1,0 +1,30 @@
+---
+/**
+ * Spinner — indicador de carga primitivo (SVG inline, sin estado).
+ *
+ * Usa `currentColor`, así que hereda el color del texto del contenedor
+ * (p. ej. dentro de un Button). Tamaño por defecto 1rem; sobreescribible
+ * con clases de tamaño en `class`. Acepta data-attrs para togglearlo por script.
+ */
+interface Props {
+  class?: string;
+  /** Si se pasa, se anuncia a lectores de pantalla; si no, es decorativo. */
+  label?: string;
+  [key: `data-${string}`]: string | boolean | number | undefined;
+}
+
+const { class: className, label, ...rest } = Astro.props;
+---
+
+<svg
+  class:list={['animate-spin h-4 w-4', className]}
+  viewBox="0 0 24 24"
+  fill="none"
+  role={label ? 'status' : undefined}
+  aria-label={label}
+  aria-hidden={label ? undefined : 'true'}
+  {...rest}
+>
+  <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+  <path class="opacity-90" fill="currentColor" d="M4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4z"></path>
+</svg>


### PR DESCRIPTION
## Contexto

Al pulsar **Enviar**, el usuario no recibía feedback inmediato: el botón se deshabilitaba durante el `fetch`, pero sin ninguna indicación visual, dando sensación de que no pasaba nada.

## Cambios
- **Nuevo `src/components/shared/Spinner.astro`**: componente primitivo reutilizable (SVG inline, hereda `currentColor`, tamaño y clases sobreescribibles, acepta `data-*`). No existía spinner previo en el proyecto.
- **`ContactSection.astro`**: el spinner se muestra en el botón mientras se envía, ocultando la flecha `→`; se marca `aria-busy` y se restaura al terminar (éxito o error). Helper `setLoading()` centraliza el estado.

## Verificación
- `npx astro check` → 0 errores.
- Render verificado en dev: spinner presente y oculto por defecto (`hidden`), selectores del script coinciden con los `data-*` del markup. La flecha y el spinner se alternan vía `setLoading()`.