### PR TITLE
chore: actualiza las actions fuera del runtime Node 20 deprecado

### DIFF
--- a/.github/workflows/check-kata-links.yml
+++ b/.github/workflows/check-kata-links.yml
@@ -17,8 +17,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
       - run: node scripts/check-kata-links.mjs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report
           path: playwright-report/


### PR DESCRIPTION
Actions avisaba de que estas acciones corren sobre **Node 20**, ya deprecado, y las estaba forzando a Node 24 en cada ejecución.

Se mantiene el **pinning por SHA** con el tag en el comentario, que es como estaban.

| cambio | ¿afecta? |
|---|---|
| checkout v7 bloquea checkout de PRs de forks en `pull_request_target` / `workflow_run` | no — no se usan esos disparadores |
| setup-node v6 limita el cacheo automático a npm | no — `test.yml` usa `cache: 'npm'` |
| todas exigen runner ≥ 2.327.1 | no — lo traen los runners hospedados |
